### PR TITLE
fixing Rprange in outspec

### DIFF
--- a/EXOSIMS/Prototypes/PlanetPopulation.py
+++ b/EXOSIMS/Prototypes/PlanetPopulation.py
@@ -90,7 +90,7 @@ class PlanetPopulation(object):
             if att == 'Mprange':
                 self._outspec[att] /= const.M_earth.value
             elif att == 'Rprange':
-                self._outspec[att] /= const.R_earth.value
+                self._outspec[att] /= const.R_earth.to('km').value
         
         # import PlanetPhysicalModel
         self.PlanetPhysicalModel = get_module(specs['modules']['PlanetPhysicalModel'], \

--- a/EXOSIMS/Prototypes/PlanetPopulation.py
+++ b/EXOSIMS/Prototypes/PlanetPopulation.py
@@ -63,7 +63,7 @@ class PlanetPopulation(object):
         self.wrange = self.checkranges(wrange,'wrange')*u.deg
         self.prange = self.checkranges(prange,'prange')
         self.Rprange = self.checkranges(Rprange,'Rprange')*const.R_earth.to('km')
-        self.Mprange = self.checkranges(Mprange,'Mprange')*const.M_earth
+        self.Mprange = self.checkranges(Mprange,'Mprange')*const.M_earth.to('kg')
         
         assert isinstance(scaleOrbits,bool), "scaleOrbits must be boolean"
         # scale planetary orbits by sqrt(L)
@@ -88,7 +88,7 @@ class PlanetPopulation(object):
             dat = copy.copy(self.__dict__[att])
             self._outspec[att] = dat.value if isinstance(dat,u.Quantity) else dat
             if att == 'Mprange':
-                self._outspec[att] /= const.M_earth.value
+                self._outspec[att] /= const.M_earth.to('kg').value
             elif att == 'Rprange':
                 self._outspec[att] /= const.R_earth.to('km').value
         


### PR DESCRIPTION
The outspec for Prototypes/PlanetPopulation was writing the Rprange incorrectly. Previously, the values were 1000x too low. The astropy constant R_earth has default units of meters whereas Rprange is in units of kilometers. When using .value, astropy takes the default unit.