### PR TITLE
changed spacecraft positon interpolation from cubic to linear

### DIFF
--- a/EXOSIMS/Observatory/WFIRSTObservatoryL2.py
+++ b/EXOSIMS/Observatory/WFIRSTObservatoryL2.py
@@ -59,10 +59,10 @@ class WFIRSTObservatoryL2(WFIRSTObservatory):
         self.orbit_time = halo['t'].flatten()/(2*np.pi)*u.year
         # create interpolant (years & AU units)
         self.orbit_interp = interpolate.interp1d(self.orbit_time.value,\
-                self.orbit_pos.value.T,kind='cubic')
+                self.orbit_pos.value.T,kind='linear')#using linear resolves conflicts with ubuntu scipy.interp1d singular matrix
         # create interpolant for orbital velocity (years & AU/yr units)
         self.orbit_V_interp = interpolate.interp1d(self.orbit_time.value,\
-                self.orbit_vel.value.T,kind='cubic')
+                self.orbit_vel.value.T,kind='linear')
 
     def orbit(self, currentTime):
         """Finds observatory orbit position vector in heliocentric equatorial frame.


### PR DESCRIPTION
Calculating the look angle of the spacecraft, I found that the look angle error of the spacecraft from actual to be less than 4.9*10^-4 milliarcseconds assuming position error was as large as the position step between spacecraft locations. In reality, the position error should be an order of magnitude smaller than the above assumed as it is the difference between a linear interpolation and spline interpolation along a fine grid of 566 points on a relatively smooth arc.