### PR TITLE
KeplerLike and SAG13 updates

### DIFF
--- a/EXOSIMS/PlanetPopulation/KeplerLike1.py
+++ b/EXOSIMS/PlanetPopulation/KeplerLike1.py
@@ -231,8 +231,8 @@ class KeplerLike1(PlanetPopulation):
         
         """
         n = self.gen_input_check(n)
+        PPMod = self.PlanetPhysicalModel
         # generate semi-major axis samples
-        
         a = self.gen_sma(n)
         # check for constrainOrbits == True for eccentricity samples
         # constant
@@ -256,8 +256,8 @@ class KeplerLike1(PlanetPopulation):
         else:
             C2 = self.enorm
         e = self.esigma*np.sqrt(-2.*np.log(C1 - C2*np.random.uniform(size=n)))
-        # generate albedo (independent)
-        p = self.gen_albedo(n)
+        # generate albedo from semi-major axis
+        p = PPMod.calc_albedo_from_sma(a)
         # generate planetary radius
         Rp = self.gen_radius(n)
         

--- a/EXOSIMS/PlanetPopulation/SAG13.py
+++ b/EXOSIMS/PlanetPopulation/SAG13.py
@@ -182,9 +182,8 @@ class SAG13(KeplerLike2):
         else:
             C2 = self.enorm
         e = self.esigma*np.sqrt(-2.*np.log(C1 - C2*np.random.uniform(size=n)))
-        # generate albedo (independent)
-        _, sma = self.gen_radius_sma(n)
-        p = self.PlanetPhysicalModel.calc_albedo_from_sma(sma)
+        # generate albedo from semi-major axis
+        p = self.PlanetPhysicalModel.calc_albedo_from_sma(a)
         
         return a, e, p, Rp
     

--- a/EXOSIMS/Prototypes/PlanetPopulation.py
+++ b/EXOSIMS/Prototypes/PlanetPopulation.py
@@ -83,7 +83,6 @@ class PlanetPopulation(object):
         er = self.erange
         if self.constrainOrbits:
             self.rrange = [ar[0], ar[1]]*u.AU
-            self.arange = [ar[0]/(1. - er[0]), ar[1]/(1. + er[0])]*u.AU
         else:
             self.rrange = [ar[0]*(1. - er[1]), ar[1]*(1. + er[1])]*u.AU
         assert isinstance(eta, numbers.Number) and (eta > 0),\

--- a/EXOSIMS/SimulatedUniverse/KeplerLikeUniverse.py
+++ b/EXOSIMS/SimulatedUniverse/KeplerLikeUniverse.py
@@ -26,7 +26,7 @@ class KeplerLikeUniverse(SimulatedUniverse):
         of the orbital elements, albedos, masses and radii of all planets, and 
         generates indices that map from planet to parent star.
         
-        All paramters except for albedo and mass are sampled, while those are
+        All parameters except for albedo and mass are sampled, while those are
         calculated via the physical model.
         """
         
@@ -42,10 +42,11 @@ class KeplerLikeUniverse(SimulatedUniverse):
         self.plan2star = np.random.randint(0,TL.nStars,self.nPlans)
         self.sInds = np.unique(self.plan2star)
         
-        self.a, self.e, _, _ = PPop.gen_plan_params(self.nPlans)
+        self.a, self.e, self.p, _ = PPop.gen_plan_params(self.nPlans)
         self.I, self.O, self.w = PPop.gen_angles(self.nPlans)
         # inflated planets have to be moved to tidally locked orbits
         self.a[self.Rp > np.nanmax(PPMod.ggdat['radii'])] = 0.02*u.AU
+        if PPop.scaleOrbits:
+            self.a *= np.sqrt(TL.L[self.plan2star])
         self.M0 = np.random.uniform(360,size=self.nPlans)*u.deg # initial mean anomaly
-        self.p = PPMod.calc_albedo_from_sma(self.a)         # albedo
-        self.Mp = PPMod.calc_mass_from_radius(self.Rp)      # mass
+        self.Mp = PPMod.calc_mass_from_radius(self.Rp)          # mass

--- a/EXOSIMS/SimulatedUniverse/SAG13Universe.py
+++ b/EXOSIMS/SimulatedUniverse/SAG13Universe.py
@@ -1,0 +1,59 @@
+from EXOSIMS.Prototypes.SimulatedUniverse import SimulatedUniverse
+import numpy as np
+import astropy.units as u
+import astropy.constants as const
+
+class SAG13Universe(SimulatedUniverse):
+    """Simulated Universe module based on SAG13 Planet Population module.
+    
+    """
+
+    def __init__(self, **specs):
+        
+        SimulatedUniverse.__init__(self, **specs)
+
+    def gen_physical_properties(self, **specs):
+        """Generating universe based on SAG13 planet radius and period sampling.
+        
+        All parameters except for albedo and mass are sampled, while those are
+        calculated via the physical model.
+        
+        """
+        
+        PPop = self.PlanetPopulation
+        PPMod = self.PlanetPhysicalModel
+        TL = self.TargetList
+        
+        # treat eta as the rate parameter of a Poisson distribution
+        targetSystems = np.random.poisson(lam=PPop.eta, size=TL.nStars)
+        plan2star = []
+        for j,n in enumerate(targetSystems):
+            plan2star = np.hstack((plan2star, [j]*n))
+        self.plan2star = plan2star.astype(int)
+        self.sInds = np.unique(self.plan2star)
+        self.nPlans = len(self.plan2star)
+        
+        # sample all of the orbital and physical parameters
+        self.I, self.O, self.w = PPop.gen_angles(self.nPlans)
+        self.a, self.e, self.p, self.Rp = PPop.gen_plan_params(self.nPlans)
+        if PPop.scaleOrbits:
+            self.a *= np.sqrt(TL.L[self.plan2star])
+        self.M0 = np.random.uniform(360, size=self.nPlans)*u.deg # initial mean anomaly
+        self.Mp = PPMod.calc_mass_from_radius(self.Rp)           # mass
+        
+        # The prototype StarCatalog module is made of one single G star at 1pc. 
+        # In that case, generate one Jupiter at 5 AU to allow for characterization 
+        # testing. Also generates at least one Jupiter if no planet was generated.
+        if TL.Name[0] == 'Prototype' or self.nPlans == 0:
+            self.plan2star = np.array([0], dtype=int)
+            self.sInds = np.unique(self.plan2star)
+            self.nPlans = len(self.plan2star)
+            self.a = np.array([5.])*u.AU
+            self.e = np.array([0.])
+            self.I = np.array([0.])*u.deg # face-on
+            self.O = np.array([0.])*u.deg
+            self.w = np.array([0.])*u.deg
+            self.M0 = np.array([0.])*u.deg
+            self.Rp = np.array([10.])*u.earthRad
+            self.Mp = np.array([300.])*u.earthMass
+            self.p = np.array([0.6])


### PR DESCRIPTION
Generate albedo based on sampled semi-major axis for KeplerLike and SAG13.

Update KeplerLikeUniverse and SAG13Universe to assign mass based on sampled planetary radius.

Remove redefinition of arange when constrainOrbits is True.