### PR TITLE
Specify #Planets per Star and Issue #108 Fix

### DIFF
--- a/EXOSIMS/Prototypes/SimulatedUniverse.py
+++ b/EXOSIMS/Prototypes/SimulatedUniverse.py
@@ -80,6 +80,8 @@ class SimulatedUniverse(object):
     Notes:
         PlanetPopulation.eta is treated as the rate parameter of a Poisson distribution.
         Each target's number of planets is a Poisson random variable sampled with \lambda=\eta.
+
+        fixedPlanPerStar can be used to specify a fixed number of planets per star
     
     """
 
@@ -141,8 +143,17 @@ class SimulatedUniverse(object):
         PPop = self.PlanetPopulation
         TL = self.TargetList
         
-        # treat eta as the rate parameter of a Poisson distribution
-        targetSystems = np.random.poisson(lam=PPop.eta, size=TL.nStars)
+        try:
+            #Check of ppStar is assigned
+            ppStar = specs['fixedPlanPerStar']
+            #Ensure it is an integer
+            assert (ppStar % 1) == 0#ppStar must be an integer
+            #Create array of length TL.nStars each w/ value ppStar
+            targetSystems = np.ones(TL.nStars).astype(int)*ppStar
+        except:
+            # treat eta as the rate parameter of a Poisson distribution
+            targetSystems = np.random.poisson(lam=PPop.eta, size=TL.nStars)
+        
         plan2star = []
         for j,n in enumerate(targetSystems):
             plan2star = np.hstack((plan2star, [j]*n))

--- a/EXOSIMS/Prototypes/SimulatedUniverse.py
+++ b/EXOSIMS/Prototypes/SimulatedUniverse.py
@@ -76,13 +76,14 @@ class SimulatedUniverse(object):
             Differences in magnitude between planets and their host star
         WA (astropy Quantity array)
             Working angles of the planets of interest in units of arcsec
+        fixedPlanPerStar (int):
+            fixed number of planets to generate per star
     
     Notes:
         PlanetPopulation.eta is treated as the rate parameter of a Poisson distribution.
         Each target's number of planets is a Poisson random variable sampled with \lambda=\eta.
 
-        fixedPlanPerStar can be used to specify a fixed number of planets per star
-    
+
     """
 
     _modtype = 'SimulatedUniverse'
@@ -145,9 +146,9 @@ class SimulatedUniverse(object):
         
         try:
             #Check of ppStar is assigned
-            ppStar = specs['fixedPlanPerStar']
+            self.fixedPlanPerStar = specs['fixedPlanPerStar']
             #Ensure it is an integer
-            assert (ppStar % 1) == 0#ppStar must be an integer
+            assert (self.fixedPlanPerStar % 1) == 0#ppStar must be an integer
             #Create array of length TL.nStars each w/ value ppStar
             targetSystems = np.ones(TL.nStars).astype(int)*ppStar
         except:

--- a/EXOSIMS/Prototypes/SimulatedUniverse.py
+++ b/EXOSIMS/Prototypes/SimulatedUniverse.py
@@ -96,6 +96,7 @@ class SimulatedUniverse(object):
 
         # save fixed number of planets to generate
         self.fixedPlanPerStar = fixedPlanPerStar
+        self._outspec['fixedPlanPerStar'] = self.fixedPlanPerStar
        
         # import TargetList class
         self.TargetList = get_module(specs['modules']['TargetList'],

--- a/EXOSIMS/Prototypes/SimulatedUniverse.py
+++ b/EXOSIMS/Prototypes/SimulatedUniverse.py
@@ -76,8 +76,8 @@ class SimulatedUniverse(object):
             Differences in magnitude between planets and their host star
         WA (astropy Quantity array)
             Working angles of the planets of interest in units of arcsec
-        fixedPlanPerStar (int):
-            fixed number of planets to generate per star
+        fixedPlanPerStar (int or None):
+            Fixed number of planets to generate for each star
     
     Notes:
         PlanetPopulation.eta is treated as the rate parameter of a Poisson distribution.
@@ -89,10 +89,13 @@ class SimulatedUniverse(object):
     _modtype = 'SimulatedUniverse'
     _outspec = {}
     
-    def __init__(self, **specs):
+    def __init__(self, fixedPlanPerStar=None, **specs):
         
         # load the vprint function (same line in all prototype module constructors)
         self.vprint = vprint(specs.get('verbose', True))
+
+        # save fixed number of planets to generate
+        self.fixedPlanPerStar = fixedPlanPerStar
        
         # import TargetList class
         self.TargetList = get_module(specs['modules']['TargetList'],
@@ -144,16 +147,13 @@ class SimulatedUniverse(object):
         PPop = self.PlanetPopulation
         TL = self.TargetList
         
-        try:
-            #Check of ppStar is assigned
-            self.fixedPlanPerStar = specs['fixedPlanPerStar']
-            #Ensure it is an integer
-            assert (self.fixedPlanPerStar % 1) == 0#ppStar must be an integer
+        if(type(self.fixedPlanPerStar) == int):#Must be an integer for fixedPlanPerStar
             #Create array of length TL.nStars each w/ value ppStar
-            targetSystems = np.ones(TL.nStars).astype(int)*ppStar
-        except:
+            targetSystems = np.ones(TL.nStars).astype(int)*self.fixedPlanPerStar
+        else:
             # treat eta as the rate parameter of a Poisson distribution
             targetSystems = np.random.poisson(lam=PPop.eta, size=TL.nStars)
+
         
         plan2star = []
         for j,n in enumerate(targetSystems):

--- a/EXOSIMS/Prototypes/SurveySimulation.py
+++ b/EXOSIMS/Prototypes/SurveySimulation.py
@@ -290,7 +290,7 @@ class SurveySimulation(object):
             # acquire the NEXT TARGET star index and create DRM
             DRM, sInd, det_intTime = self.next_target(sInd, det_mode)
             assert det_intTime != 0, "Integration time can't be 0."
-            
+
             if sInd is not None:
                 cnt += 1
                 # get the index of the selected target for the extended list
@@ -487,6 +487,12 @@ class SurveySimulation(object):
             if len(sInds) > 0:
                 # choose sInd of next target
                 sInd = self.choose_next_target(old_sInd, sInds, slewTimes, intTimes[sInds])
+                #Should Choose Next Target decide there are no stars it wishes to observe at this time.
+                if sInd == None:
+                    TK.allocate_time(TK.waitTime)
+                    intTime = None
+                    self.vprint('There are no stars Choose Next Target would like to Observe. Waiting 1d')
+                    continue
                 # store selected star integration time
                 intTime = intTimes[sInd]
                 break
@@ -547,7 +553,6 @@ class SurveySimulation(object):
         intTimes = self.OpticalSystem.calc_intTime(self.TargetList, sInds, fZ, fEZ, dMag, WA, mode)
         
         return intTimes
-
 
     def choose_next_target(self, old_sInd, sInds, slewTimes, intTimes):
         """Helper method for method next_target to simplify alternative implementations.

--- a/EXOSIMS/SurveySimulation/starkAYO_staticSchedule.py
+++ b/EXOSIMS/SurveySimulation/starkAYO_staticSchedule.py
@@ -260,7 +260,7 @@ class starkAYO_staticSchedule(SurveySimulation):
                 TK.allocate_time(TK.waitTime*TK.waitMultiple**cnt)
                 cnt += 1
         else:
-            return None#DRM, None, None
+            return None
         return sInd
 
     def calc_targ_intTime(self, sInds, startTimes, mode):


### PR DESCRIPTION
When using the prototype SimulatedUniverse, you can specify fixedPlanPerStar to statically fix the number of planets generated per star. These must be given in integer values tested up to 100.

The choose_next_target method can now return None as an sInd and the next_target method will wait 1 day.