### PR TITLE
PlanetPopulation module assigning constant albedos over ranges of planetary radius

### DIFF
--- a/EXOSIMS/Completeness/GarrettCompleteness.py
+++ b/EXOSIMS/Completeness/GarrettCompleteness.py
@@ -390,6 +390,49 @@ class GarrettCompleteness(BrownCompleteness):
         
         return f
     
+    def f_dmagsRp(self, Rp, dmag, s):
+        """Calculates the joint probability density of planetary radius, 
+        dMag, and projected separation
+        
+        Args:
+            Rp (ndarray):
+                Values of planetary radius
+            dmag (float):
+                Planet delta magnitude
+            s (float):
+                Value of projected separation
+        
+        Returns:
+            f (ndarray):
+                Values of joint probability density
+                
+        """
+        if not isinstance(Rp,np.ndarray):
+            Rp = np.array(Rp, ndmin=1, copy=False)
+
+        vals = (s/self.x)**2*10.**(-0.4*dmag)/self.PlanetPopulation.get_p_from_Rp(Rp)/Rp**2
+        
+        f = np.zeros(Rp.shape)
+        fa = f[vals<self.val]
+        Rpa = Rp[vals<self.val]
+        valsa = vals[vals<self.val]
+        b1 = self.binv1(valsa)
+        b2 = self.binv2(valsa)
+        r1 = s/np.sin(b1)
+        r2 = s/np.sin(b2)
+        good1 = ((r1>self.rmin)&(r1<self.rmax))
+        good2 = ((r2>self.rmin)&(r2<self.rmax))
+        if (self.pconst & self.Rconst):
+            fa[good1] = np.sin(b1[good1])/2.0*self.dist_r(r1[good1])/np.abs(self.Jac(b1[good1]))
+            fa[good2] += np.sin(b2[good2])/2.0*self.dist_r(r2[good2])/np.abs(self.Jac(b2[good2]))
+        else:
+            fa[good1] = self.dist_radius(Rpa[good1])*np.sin(b1[good1])/2.0*self.dist_r(r1[good1])/np.abs(self.Jac(b1[good1]))
+            fa[good2] += self.dist_radius(Rpa[good2])*np.sin(b2[good2])/2.0*self.dist_r(r2[good2])/np.abs(self.Jac(b2[good2]))
+            
+        f[vals<self.val] = fa
+        
+        return f
+    
     def mindmag(self, s):
         """Calculates the minimum value of dMag for projected separation
         

--- a/EXOSIMS/Completeness/GarrettCompleteness.py
+++ b/EXOSIMS/Completeness/GarrettCompleteness.py
@@ -336,7 +336,54 @@ class GarrettCompleteness(BrownCompleteness):
                     f += np.sin(b2)/2.0*self.dist_z(z2)*z2*np.log(10.0)/(-2.5*self.amax*np.cos(b2))
             else:
                 ztest = (s/self.x)**2*10.**(-0.4*dmag)/self.val
-                if ztest >= self.zmax:
+                if self.PlanetPopulation.pfromRp:
+#                    f = 0.0
+#                    minR = self.PlanetPopulation.Rbs[:-1]
+#                    maxR = self.PlanetPopulation.Rbs[1:]
+#                    minR = np.hstack((minR,self.Rmin))
+#                    maxR = np.hstack((maxR,self.Rmax))
+#                    minR.sort()
+#                    maxR.sort()
+##                    minR = minR[(minR>=self.Rmin)&(minR<=self.Rmax)]
+##                    maxR = maxR[(maxR>=self.Rmax)&(maxR<=self.Rmax)]
+#                    print('minR: {} maxR: {}'.format(minR,maxR))
+#                    minz = self.PlanetPopulation.get_p_from_Rp(minR*u.earthRad)*minR**2
+#                    maxz = self.PlanetPopulation.get_p_from_Rp(maxR*u.earthRad)*maxR**2
+#                    if ztest > maxz[-1]:
+#                        f = 0.0
+#                    else:
+#                        ptest = self.PlanetPopulation.get_p_from_Rp(minR*u.earthRad)
+#                        minR[ztest>minz] = np.sqrt(ztest/ptest[ztest>minz])
+#                        mask = minR < maxR
+#                        print('minR: {} maxR: {} mask: {}'.format(minR,maxR,mask))
+#                        minR = minR[mask]
+#                        maxR = maxR[mask]
+#                        f = 0.0
+#                        for i in xrange(len(minR)):
+#                            f += integrate.fixed_quad(self.f_dmagsRp, minR[i], maxR[i], args=(dmag,s), n=200)[0]
+                    f = 0.0
+                    minR = self.PlanetPopulation.Rbs[:-1]
+                    maxR = self.PlanetPopulation.Rbs[1:]
+                    for i in xrange(len(minR)):
+                        ptest = self.PlanetPopulation.get_p_from_Rp(minR[i]*u.earthRad)
+                        Rtest = np.sqrt(ztest/ptest)
+                        if Rtest > minR[i]:
+                            if Rtest > self.Rmin:
+                                Rl = Rtest
+                            else:
+                                Rl = self.Rmin
+                        else:
+                            if self.Rmin > minR[i]:
+                                Rl = self.Rmin
+                            else:
+                                Rl = minR[i]
+                        if self.Rmax > maxR[i]:
+                            Ru = maxR[i]
+                        else:
+                            Ru = self.Rmax
+                        if Rl < Ru:
+                            f += integrate.fixed_quad(self.f_dmagsRp, Rl, Ru, args=(dmag,s), n=200)[0]
+                elif ztest >= self.zmax:
                     f = 0.0
                 elif (self.pconst & self.Rconst):
                     f = self.f_dmagsz(self.zmin,dmag,s)
@@ -410,7 +457,7 @@ class GarrettCompleteness(BrownCompleteness):
         if not isinstance(Rp,np.ndarray):
             Rp = np.array(Rp, ndmin=1, copy=False)
 
-        vals = (s/self.x)**2*10.**(-0.4*dmag)/self.PlanetPopulation.get_p_from_Rp(Rp)/Rp**2
+        vals = (s/self.x)**2*10.**(-0.4*dmag)/self.PlanetPopulation.get_p_from_Rp(Rp*u.earthRad)/Rp**2
         
         f = np.zeros(Rp.shape)
         fa = f[vals<self.val]

--- a/EXOSIMS/PlanetPopulation/AlbedoByRadius.py
+++ b/EXOSIMS/PlanetPopulation/AlbedoByRadius.py
@@ -1,8 +1,6 @@
 from EXOSIMS.PlanetPopulation.SAG13 import SAG13
 import astropy.units as u
-import astropy.constants as const
 import numpy as np
-import scipy.integrate as integrate
 
 class AlbedoByRadius(SAG13):
     """Planet Population module based on SAG13 occurrence rates.

--- a/EXOSIMS/PlanetPopulation/AlbedoByRadius.py
+++ b/EXOSIMS/PlanetPopulation/AlbedoByRadius.py
@@ -111,7 +111,7 @@ class AlbedoByRadius(SAG13):
         return a, e, p, Rp
     
     def get_p_from_Rp(self, Rp):
-        """Generate albedos from radius ranges
+        """Generate constant albedos for radius ranges
         
         Args:
             Rp (astropy Quantity array):

--- a/EXOSIMS/PlanetPopulation/AlbedoByRadius.py
+++ b/EXOSIMS/PlanetPopulation/AlbedoByRadius.py
@@ -1,0 +1,110 @@
+from EXOSIMS.PlanetPopulation.SAG13 import SAG13
+import astropy.units as u
+import astropy.constants as const
+import numpy as np
+import scipy.integrate as integrate
+
+class AlbedoByRadius(SAG13):
+    """Planet Population module based on SAG13 occurrence rates.
+    
+    NOTE: This assigns constant albedo based on radius range.
+    
+    Attributes: 
+        SAG13coeffs (float 4x2 ndarray):
+            Coefficients used by the SAG13 broken power law. The 4 lines
+            correspond to Gamma, alpha, beta, and the minimum radius.
+        Gamma (float ndarray):
+            Gamma coefficients used by SAG13 broken power law.
+        alpha (float ndarray):
+            Alpha coefficients used by SAG13 broken power law.
+        beta (float ndarray):
+            Beta coefficients used by SAG13 broken power law.
+        Rplim (float ndarray):
+            Minimum radius used by SAG13 broken power law.
+        SAG13starMass (astropy Quantity):
+            Assumed stellar mass corresponding to the given set of coefficients.
+        mu (astropy Quantity):
+            Gravitational parameter associated with SAG13starMass.
+        Ca (float 2x1 ndarray):
+            Constants used for sampling.
+        ps (float nx1 ndarray):
+            Constant geometric albedo values.
+        Rb (float (n-1)x1 ndarray):
+            Planetary radius break points for albedos in earthRad.
+    
+    """
+    
+    def __init__(self, SAG13coeffs=[[.38, -.19, .26, 0.],[.73, -1.18, .59, 3.4]],
+            SAG13starMass=1., Rprange=[2/3., 17.0859375],
+            arange=[0.09084645, 1.45354324], ps=[0.2,0.5], Rb=[1.4], **specs):
+        
+        SAG13.__init__(self, SAG13coeffs=SAG13coeffs, SAG13starMass=SAG13starMass,
+                       Rprange=Rprange, arange=arange, **specs)
+        
+        self.ps = np.array(ps, copy=False)
+        self.Rb = np.array(Rb, copy=False)
+        # check to ensure proper inputs
+        assert len(self.ps) - len(self.Rb) == 1, \
+            'input albedos must have one more element than break radii'
+        
+        # populate _outspec with new specific attributes
+        self._outspec['ps'] = self.ps
+        self._outspec['Rb'] = self.Rb
+        
+    def gen_plan_params(self, n):
+        """Generate semi-major axis (AU), eccentricity, geometric albedo, and
+        planetary radius (earthRad)
+        
+        Semi-major axis and planetary radius are jointly distributed. 
+        Eccentricity is a Rayleigh distribution. Albedo is a constant value
+        based on planetary radius.
+        
+        Args:
+            n (integer):
+                Number of samples to generate
+        
+        Returns:
+            a (astropy Quantity array):
+                Semi-major axis in units of AU
+            e (float ndarray):
+                Eccentricity
+            p (float ndarray):
+                Geometric albedo
+            Rp (astropy Quantity array):
+                Planetary radius in units of earthRad
+        
+        """
+        n = self.gen_input_check(n)
+        # generate semi-major axis and planetary radius samples
+        Rp, a = self.gen_radius_sma(n)
+        
+        # check for constrainOrbits == True for eccentricity samples
+        # constants
+        C1 = np.exp(-self.erange[0]**2/(2.*self.esigma**2))
+        ar = self.arange.to('AU').value
+        if self.constrainOrbits:
+            # restrict semi-major axis limits
+            arcon = np.array([ar[0]/(1.-self.erange[0]), ar[1]/(1.+self.erange[0])])
+            # clip sma values to sma range
+            sma = np.clip(a.to('AU').value, arcon[0], arcon[1])
+            # upper limit for eccentricity given sma
+            elim = np.zeros(len(sma))
+            amean = np.mean(arcon)
+            elim[sma <= amean] = 1. - ar[0]/sma[sma <= amean]
+            elim[sma > amean] = ar[1]/sma[sma>amean] - 1.
+            elim[elim > self.erange[1]] = self.erange[1]
+            elim[elim < self.erange[0]] = self.erange[0]
+            # additional constant
+            C2 = C1 - np.exp(-elim**2/(2.*self.esigma**2))
+            a = sma*u.AU
+        else:
+            C2 = self.enorm
+        e = self.esigma*np.sqrt(-2.*np.log(C1 - C2*np.random.uniform(size=n)))
+        # generate albedo from planetary radius
+        Rs = np.hstack((0.,self.Rb,np.inf))
+        p = np.zeros((n,))
+        for i in xrange(len(Rs)-1):
+            mask = np.where((Rp.to('earthRad').value>=Rs[i])&(Rp.to('earthRad').value<Rs[i+1]))
+            p[mask] = self.ps[i]
+        
+        return a, e, p, Rp

--- a/EXOSIMS/PlanetPopulation/AlbedoByRadius.py
+++ b/EXOSIMS/PlanetPopulation/AlbedoByRadius.py
@@ -41,7 +41,8 @@ class AlbedoByRadius(SAG13):
             SAG13starMass=1., Rprange=[2/3., 17.0859375],
             arange=[0.09084645, 1.45354324], ps=[0.2,0.5], Rb=[1.4], **specs):
         
-        SAG13.__init__(self, SAG13coeffs=SAG13coeffs, SAG13starMass=SAG13starMass,
+        specs['prange'] = [np.min(ps), np.max(ps)]
+        SAG13.__init__(self, SAG13coeffs=SAG13coeffs, SAG13starMass=SAG13starMass, 
                        Rprange=Rprange, arange=arange, **specs)
         
         # cast inputs to arrays

--- a/EXOSIMS/PlanetPopulation/AlbedoByRadius.py
+++ b/EXOSIMS/PlanetPopulation/AlbedoByRadius.py
@@ -52,6 +52,9 @@ class AlbedoByRadius(SAG13):
             'input albedos must have one more element than break radii'
         self.Rbs = np.hstack((0.0,self.Rb,np.inf))
         
+        # albedo is constant for planetary radius range
+        self.pfromRp = True
+        
         # populate _outspec with new specific attributes
         self._outspec['ps'] = self.ps
         self._outspec['Rb'] = self.Rb

--- a/EXOSIMS/PlanetPopulation/AlbedoByRadius.py
+++ b/EXOSIMS/PlanetPopulation/AlbedoByRadius.py
@@ -31,7 +31,7 @@ class AlbedoByRadius(SAG13):
             Constant geometric albedo values.
         Rb (float (n-1)x1 ndarray):
             Planetary radius break points for albedos in earthRad.
-        Rs (float (n+1)x1 ndarray):
+        Rbs (float (n+1)x1 ndarray):
             Planetary radius break points with 0 padded on left and np.inf 
             padded on right
     
@@ -50,7 +50,7 @@ class AlbedoByRadius(SAG13):
         # check to ensure proper inputs
         assert len(self.ps) - len(self.Rb) == 1, \
             'input albedos must have one more element than break radii'
-        self.Rs = np.hstack((0.0,self.Rb,np.inf))
+        self.Rbs = np.hstack((0.0,self.Rb,np.inf))
         
         # populate _outspec with new specific attributes
         self._outspec['ps'] = self.ps
@@ -124,8 +124,8 @@ class AlbedoByRadius(SAG13):
         """
         Rp = np.array(Rp.to('earthRad').value, ndmin=1, copy=False)
         p = np.zeros(Rp.shape)
-        for i in xrange(len(self.Rs)-1):
-            mask = np.where((Rp>=self.Rs[i])&(Rp<self.Rs[i+1]))
+        for i in xrange(len(self.Rbs)-1):
+            mask = np.where((Rp>=self.Rbs[i])&(Rp<self.Rbs[i+1]))
             p[mask] = self.ps[i]
         
         return p

--- a/EXOSIMS/PlanetPopulation/SAG13.py
+++ b/EXOSIMS/PlanetPopulation/SAG13.py
@@ -211,8 +211,8 @@ class SAG13(KeplerLike2):
         R = np.array(R, ndmin=1, copy=False)
         aa, RR = np.meshgrid(a,R)
 
-        mu = self.mu.to('AU3/year2')
-        
+        mu = self.mu.to('AU3/year2').value
+
         f = np.zeros(aa.shape)
         mask1 = RR < self.Rplim[1]
         mask2 = RR > self.Rplim[1]

--- a/EXOSIMS/Prototypes/PlanetPopulation.py
+++ b/EXOSIMS/Prototypes/PlanetPopulation.py
@@ -91,6 +91,9 @@ class PlanetPopulation(object):
         # star in a given universe
         self.eta = eta
         
+        # albedo is constant for planetary radius range
+        self.pfromRp = False
+        
         # populate all attributes to outspec
         for att in self.__dict__.keys():
             if att not in ['vprint']:

--- a/tests/PlanetPopulation/test_PlanetPopulation.py
+++ b/tests/PlanetPopulation/test_PlanetPopulation.py
@@ -128,7 +128,7 @@ class TestPlanetPopulation(unittest.TestCase):
         and is used when generating p samples.
         """
 
-        exclude_setrange = ['EarthTwinHabZone1','EarthTwinHabZone2','JupiterTwin']
+        exclude_setrange = ['EarthTwinHabZone1','EarthTwinHabZone2','JupiterTwin','AlbedoByRadius']
         exclude_checkrange = ['KeplerLike1','SAG13']
 
         tmp = np.random.rand(1)*0.5


### PR DESCRIPTION
New module called AlbedoByRadius works with BrownCompleteness and GarrettCompleteness
ps: (n) array of albedo values (default: ps = [0.2, 0.5]
Rb: (n-1) array of radius break points listed from smallest to largest (default: Rb = [1.4])

Operating assumption is that the radius array is always padded by 0 on the left and np.inf on the right (so the default assigns 0.2 to everything under 1.4 and 0.5 to everything >= 1.4 R_earth)