### PR TITLE
Python 3 compatibility

### DIFF
--- a/EXOSIMS/BackgroundSources/GalaxiesFaintStars.py
+++ b/EXOSIMS/BackgroundSources/GalaxiesFaintStars.py
@@ -58,11 +58,11 @@ class GalaxiesFaintStars(BackgroundSources):
         lat_pts = np.array([0., 5, 10, 20, 30, 60, 90]) # deg
         mag_pts = np.array([15., 16, 17, 18, 19, 20, 21, 22, 23, 24, 25])
         y_pts, x_pts = np.meshgrid(mag_pts, lat_pts)
-        points = np.array(zip(np.concatenate(x_pts), np.concatenate(y_pts)))
+        points = np.array(list(zip(np.concatenate(x_pts), np.concatenate(y_pts))))
         # create data values
         values = table.reshape(table.size)
         # interpolates 2D
-        C_st = griddata(points,values,zip(lat,mag)) # log values
+        C_st = griddata(points,values,np.array(list(zip(lat,mag)))) # log values
         C_st = 10**C_st/3600
         
         # Galaxy count per square arcmin, from Windhorst et al 2011 

--- a/EXOSIMS/Completeness/BrownCompleteness.py
+++ b/EXOSIMS/Completeness/BrownCompleteness.py
@@ -64,7 +64,7 @@ class BrownCompleteness(Completeness):
         for att in sorted(atts, key=str.lower):
             if not callable(getattr(self.PlanetPopulation, att)) and att != 'PlanetPhysicalModel':
                 self.extstr += '%s: ' % att + str(getattr(self.PlanetPopulation, att)) + ' '
-        ext = hashlib.md5(self.extstr).hexdigest()
+        ext = hashlib.md5(self.extstr.encode("utf-8")).hexdigest()
         self.filename += ext
 
     def target_completeness(self, TL):
@@ -177,7 +177,7 @@ class BrownCompleteness(Completeness):
         OWA = mode['OWA']
         extstr = self.extstr + 'IWA: ' + str(IWA) + ' OWA: ' + str(OWA) + \
                 ' dMagMax: ' + str(dMagMax) + ' nStars: ' + str(TL.nStars)
-        ext = hashlib.md5(extstr).hexdigest()
+        ext = hashlib.md5(extstr.encode('utf-8')).hexdigest()
         self.dfilename += ext 
         self.dfilename += '.dcomp'
 

--- a/EXOSIMS/Completeness/BrownCompleteness.py
+++ b/EXOSIMS/Completeness/BrownCompleteness.py
@@ -338,7 +338,8 @@ class BrownCompleteness(Completeness):
         # if the 2D completeness pdf array exists as a .comp file load it
         if os.path.exists(Cpath):
             self.vprint('Loading cached completeness file from "%s".' % Cpath)
-            H = pickle.load(open(Cpath, 'rb'))
+            with open(Cpath, 'rb') as f1:
+                H = pickle.load(f1)
             self.vprint('Completeness loaded from cache.')
         else:
             # run Monte Carlo simulation and pickle the resulting array
@@ -363,7 +364,8 @@ class BrownCompleteness(Completeness):
             H = H/(self.Nplanets*(xedges[1]-xedges[0])*(yedges[1]-yedges[0]))
                         
             # store 2D completeness pdf array as .comp file
-            pickle.dump(H, open(Cpath, 'wb'))
+            with open(Cpath, 'wb') as ff:
+                pickle.dump(H, ff)
             self.vprint('Monte Carlo completeness calculations finished')
             self.vprint('2D completeness array stored in %r' % Cpath)
         

--- a/EXOSIMS/Completeness/BrownCompleteness.py
+++ b/EXOSIMS/Completeness/BrownCompleteness.py
@@ -59,7 +59,7 @@ class BrownCompleteness(Completeness):
                          specs['modules']['OpticalSystem'] + \
                          specs['modules']['StarCatalog'] + \
                          specs['modules']['TargetList']
-        atts = self.PlanetPopulation.__dict__.keys()
+        atts = list(self.PlanetPopulation.__dict__)
         self.extstr = ''
         for att in sorted(atts, key=str.lower):
             if not callable(getattr(self.PlanetPopulation, att)) and att != 'PlanetPhysicalModel':

--- a/EXOSIMS/Completeness/BrownCompleteness.py
+++ b/EXOSIMS/Completeness/BrownCompleteness.py
@@ -122,7 +122,7 @@ class BrownCompleteness(Completeness):
             
         # calculate separations based on IWA and OWA
         OS = TL.OpticalSystem
-        mode = filter(lambda mode: mode['detectionMode'] == True, OS.observingModes)[0]
+        mode = list(filter(lambda mode: mode['detectionMode'] == True, OS.observingModes))[0]
         IWA = mode['IWA']
         OWA = mode['OWA']
         smin = np.tan(IWA)*TL.dist
@@ -172,7 +172,7 @@ class BrownCompleteness(Completeness):
         
         # get name for stored dynamic completeness updates array
         # inner and outer working angles for detection mode
-        mode = filter(lambda mode: mode['detectionMode'] == True, OS.observingModes)[0]
+        mode = list(filter(lambda mode: mode['detectionMode'] == True, OS.observingModes))[0]
         IWA = mode['IWA']
         OWA = mode['OWA']
         extstr = self.extstr + 'IWA: ' + str(IWA) + ' OWA: ' + str(OWA) + \

--- a/EXOSIMS/Completeness/BrownCompleteness.py
+++ b/EXOSIMS/Completeness/BrownCompleteness.py
@@ -13,6 +13,11 @@ import hashlib
 from EXOSIMS.Prototypes.Completeness import Completeness
 from EXOSIMS.util.eccanom import eccanom
 from EXOSIMS.util.deltaMag import deltaMag
+import sys
+
+# Python 3 compatibility:
+if sys.version_info[0] > 2:
+    xrange = range
 
 class BrownCompleteness(Completeness):
     """Completeness class template

--- a/EXOSIMS/Completeness/GarrettCompleteness.py
+++ b/EXOSIMS/Completeness/GarrettCompleteness.py
@@ -176,7 +176,7 @@ class GarrettCompleteness(BrownCompleteness):
         dist_sv = np.vectorize(dist_s.integral, otypes=[np.float64])
         
         # calculate separations based on IWA
-        mode = filter(lambda mode: mode['detectionMode'] == True, OS.observingModes)[0]
+        mode = list(filter(lambda mode: mode['detectionMode'] == True, OS.observingModes))[0]
         IWA = mode['IWA']
         OWA = mode['OWA']
         smin = (np.tan(IWA)*TL.dist).to('AU').value

--- a/EXOSIMS/Completeness/GarrettCompleteness.py
+++ b/EXOSIMS/Completeness/GarrettCompleteness.py
@@ -161,7 +161,7 @@ class GarrettCompleteness(BrownCompleteness):
         dMagMax = self.dMagLim
         
         # important PlanetPopulation attributes
-        atts = self.PlanetPopulation.__dict__.keys()
+        atts = list(self.PlanetPopulation.__dict__)
         extstr = ''
         for att in sorted(atts, key=str.lower):
             if not callable(getattr(self.PlanetPopulation, att)) and att != 'PlanetPhysicalModel':

--- a/EXOSIMS/Completeness/GarrettCompleteness.py
+++ b/EXOSIMS/Completeness/GarrettCompleteness.py
@@ -168,7 +168,7 @@ class GarrettCompleteness(BrownCompleteness):
                 extstr += '%s: ' % att + str(getattr(self.PlanetPopulation, att)) + ' '
         # include dMagMax
         extstr += '%s: ' % 'dMagMax' + str(dMagMax) + ' '
-        ext = hashlib.md5(extstr).hexdigest()
+        ext = hashlib.md5(extstr.encode('utf-8')).hexdigest()
         self.filename += ext
         Cpath = os.path.join(self.cachedir, self.filename+'.acomp')
         

--- a/EXOSIMS/Completeness/GarrettCompleteness.py
+++ b/EXOSIMS/Completeness/GarrettCompleteness.py
@@ -12,6 +12,11 @@ try:
 except ImportError:
     import pickle
 from EXOSIMS.util.memoize import memoize
+import sys
+
+# Python 3 compatibility:
+if sys.version_info[0] > 2:
+    xrange = range
 
 class GarrettCompleteness(BrownCompleteness):
     """Analytical Completeness class

--- a/EXOSIMS/MissionSim.py
+++ b/EXOSIMS/MissionSim.py
@@ -114,7 +114,7 @@ class MissionSim(object):
             specs_from_file = {}
         specs.update(specs_from_file)
         
-        if 'modules' not in specs.keys():
+        if 'modules' not in specs:
             raise ValueError("No modules field found in script.")
         
         # set up the verbose level
@@ -139,7 +139,7 @@ class MissionSim(object):
                 + ' (%s)'%self.loglevel)
         
         # populate outspec
-        for att in self.__dict__.keys():
+        for att in self.__dict__:
             if att not in ['vprint']:
                 self._outspec[att] = self.__dict__[att]
 

--- a/EXOSIMS/MissionSim.py
+++ b/EXOSIMS/MissionSim.py
@@ -310,7 +310,7 @@ class MissionSim(object):
 
         # Only considering detections
         allModes = OS.observingModes
-        det_mode = filter(lambda mode: mode['detectionMode'] == True, allModes)[0]
+        det_mode = list(filter(lambda mode: mode['detectionMode'] == True, allModes))[0]
         mpath = os.path.split(inspect.getfile(self.__class__))[0]
 
         startTimes = TK.currentTimeAbs + np.zeros(TL.nStars)*u.d

--- a/EXOSIMS/Observatory/SotoStarshade.py
+++ b/EXOSIMS/Observatory/SotoStarshade.py
@@ -84,7 +84,7 @@ class SotoStarshade(ObservatoryL2Halo):
         extstr += '%s: ' % 'occulterSep'  + str(getattr(self,'occulterSep'))  + ' '
         extstr += '%s: ' % 'period_halo'  + str(getattr(self,'period_halo'))  + ' '
         extstr += '%s: ' % 'f_nStars'  + str(getattr(self,'f_nStars'))  + ' '
-        ext = hashlib.md5(extstr).hexdigest()
+        ext = hashlib.md5(extstr.encode('utf-8')).hexdigest()
         filename += ext
         dVpath = os.path.join(self.cachedir, filename + '.dVmap')
         

--- a/EXOSIMS/PlanetPhysicalModel/Forecaster.py
+++ b/EXOSIMS/PlanetPhysicalModel/Forecaster.py
@@ -3,8 +3,14 @@ from EXOSIMS.util.get_dirs import get_downloads_dir
 import astropy.units as u
 import numpy as np
 import os, h5py
-import urllib
 from scipy.stats import norm
+import sys
+
+# Python 3 compatibility:
+if sys.version_info[0] > 2:
+    from urllib.request import urlretrieve
+else:
+    from urllib import urlretrieve
 
 
 class Forecaster(FortneyMarleyCahoyMix1):
@@ -35,7 +41,7 @@ class Forecaster(FortneyMarleyCahoyMix1):
             fitting_url = 'https://raw.github.com/dsavransky/forecaster/master/fitting_parameters.h5'
             self.vprint("Fetching Forecaster fitting parameters from %s to %s" % (fitting_url, parampath))
             try:
-                urllib.urlretrieve(fitting_url, parampath)
+                urlretrieve(fitting_url, parampath)
             except:
                 self.vprint("Error: Remote fetch failed. Fetch manually or see install instructions.")
 

--- a/EXOSIMS/PlanetPhysicalModel/FortneyMarleyCahoyMix1.py
+++ b/EXOSIMS/PlanetPhysicalModel/FortneyMarleyCahoyMix1.py
@@ -79,7 +79,8 @@ class FortneyMarleyCahoyMix1(PlanetPhysicalModel):
             classpath = os.path.split(inspect.getfile(self.__class__))[0]
             matpath = os.path.join(classpath,'fortney_table4.mat')
             self.ggdat = loadmat(matpath, squeeze_me=True, struct_as_record=False)
-            pickle.dump( self.ggdat, open( datapath, 'wb' ) )
+            with open(datapath, 'wb') as f:
+                pickle.dump(self.ggdat, f)
         
         self.ggdat['dist'] = self.ggdat['dist']*u.AU
         self.ggdat['planet_mass'] = self.ggdat['planet_mass']*u.earthMass

--- a/EXOSIMS/PlanetPhysicalModel/FortneyMarleyCahoyMix1.py
+++ b/EXOSIMS/PlanetPhysicalModel/FortneyMarleyCahoyMix1.py
@@ -8,6 +8,7 @@ try:
 except:
     import pickle
 from scipy.io import loadmat
+import sys
 
 
 class FortneyMarleyCahoyMix1(PlanetPhysicalModel):
@@ -66,7 +67,14 @@ class FortneyMarleyCahoyMix1(PlanetPhysicalModel):
         filename = 'Fortney_etal_2007_table4.p'
         datapath = os.path.join(self.cachedir, filename)
         if os.path.exists(datapath):
-            self.ggdat = pickle.load( open( datapath, "rb" ) )
+            if sys.version_info[0] > 2:
+                with open(datapath, "rb") as f:
+                    self.ggdat = pickle.load(f, encoding='latin1')
+                # self.ggdat = pickle.load( open( datapath, "rb" ), encoding='latin1' )
+            else:
+                with open(datapath, "rb") as f:
+                    self.ggdat = pickle.load(f)
+                # self.ggdat = pickle.load( open( datapath, "rb") )
         else:
             classpath = os.path.split(inspect.getfile(self.__class__))[0]
             matpath = os.path.join(classpath,'fortney_table4.mat')

--- a/EXOSIMS/PlanetPopulation/AlbedoByRadius.py
+++ b/EXOSIMS/PlanetPopulation/AlbedoByRadius.py
@@ -1,6 +1,11 @@
 from EXOSIMS.PlanetPopulation.SAG13 import SAG13
 import astropy.units as u
 import numpy as np
+import sys
+
+# Python 3 compatibility:
+if sys.version_info[0] > 2:
+    xrange = range
 
 class AlbedoByRadius(SAG13):
     """Planet Population module based on SAG13 occurrence rates.

--- a/EXOSIMS/PlanetPopulation/DulzPlavchan.py
+++ b/EXOSIMS/PlanetPopulation/DulzPlavchan.py
@@ -6,6 +6,11 @@ from astropy.io import ascii
 import astropy.units as u
 import astropy.constants as const
 import scipy.interpolate as interpolate
+import sys
+
+# Python 3 compatibility:
+if sys.version_info[0] > 2:
+    xrange = range
 
 class DulzPlavchan(PlanetPopulation):
     """

--- a/EXOSIMS/PlanetPopulation/KeplerLike1.py
+++ b/EXOSIMS/PlanetPopulation/KeplerLike1.py
@@ -5,6 +5,11 @@ import astropy.constants as const
 import numpy as np
 import scipy.integrate as integrate
 import scipy.interpolate as interpolate
+import sys
+
+# Python 3 compatibility:
+if sys.version_info[0] > 2:
+    xrange = range
 
 class KeplerLike1(PlanetPopulation):
     """Population based on Kepler radius distribution with RV-like semi-major axis

--- a/EXOSIMS/PlanetPopulation/KeplerLike2.py
+++ b/EXOSIMS/PlanetPopulation/KeplerLike2.py
@@ -1,8 +1,7 @@
 from EXOSIMS.PlanetPopulation.KeplerLike1 import KeplerLike1
 from EXOSIMS.util.InverseTransformSampler import InverseTransformSampler
 import astropy.units as u
-import numpy as np
-import scipy.integrate as integrate
+
 
 class KeplerLike2(KeplerLike1):
     """

--- a/EXOSIMS/PlanetPopulation/SAG13.py
+++ b/EXOSIMS/PlanetPopulation/SAG13.py
@@ -4,6 +4,11 @@ import astropy.units as u
 import astropy.constants as const
 import numpy as np
 import scipy.integrate as integrate
+import sys
+
+# Python 3 compatibility:
+if sys.version_info[0] > 2:
+    xrange = range
 
 class SAG13(KeplerLike2):
     """Planet Population module based on SAG13 occurrence rates.

--- a/EXOSIMS/Prototypes/BackgroundSources.py
+++ b/EXOSIMS/Prototypes/BackgroundSources.py
@@ -39,7 +39,7 @@ class BackgroundSources(object):
         
         """
         
-        for att in self.__dict__.keys():
+        for att in self.__dict__:
             print('%s: %r' % (att, getattr(self, att)))
         
         return 'Background Sources class object attributes'

--- a/EXOSIMS/Prototypes/Completeness.py
+++ b/EXOSIMS/Prototypes/Completeness.py
@@ -37,12 +37,12 @@ class Completeness(object):
        
         #if specs contains a completeness_spec then we are going to generate separate instances
         #of planet population and planet physical model for completeness and for the rest of the sim
-        if specs.has_key('completeness_specs'):
-            if not specs['completeness_specs'].has_key('modules'):
+        if 'completeness_specs' in specs:
+            if not 'modules' in specs['completeness_specs']:
                 specs['completeness_specs']['modules'] = {}
-            if not specs['completeness_specs']['modules'].has_key('PlanetPhysicalModel'):
+            if not 'PlanetPhysicalModel' in specs['completeness_specs']['modules']:
                 specs['completeness_specs']['modules']['PlanetPhysicalModel'] = specs['modules']['PlanetPhysicalModel']
-            if not specs['completeness_specs']['modules'].has_key('PlanetPopulation'):
+            if not 'PlanetPopulation' in specs['completeness_specs']['modules']:
                 specs['completeness_specs']['modules']['PlanetPopulation'] = specs['modules']['PlanetPopulation']
             self.PlanetPopulation = get_module(specs['completeness_specs']['modules']['PlanetPopulation'],'PlanetPopulation')(**specs['completeness_specs'])
         else:

--- a/EXOSIMS/Prototypes/Completeness.py
+++ b/EXOSIMS/Prototypes/Completeness.py
@@ -71,7 +71,7 @@ class Completeness(object):
         
         """
         
-        for att in self.__dict__.keys():
+        for att in self.__dict__:
             print('%s: %r' % (att, getattr(self, att)))
         
         return 'Completeness class object attributes'

--- a/EXOSIMS/Prototypes/Observatory.py
+++ b/EXOSIMS/Prototypes/Observatory.py
@@ -14,6 +14,11 @@ except:
 import hashlib
 import os
 import urllib
+import sys
+
+# Python 3 compatibility:
+if sys.version_info[0] > 2:
+    xrange = range
 
 class Observatory(object):
     """Observatory class template

--- a/EXOSIMS/Prototypes/Observatory.py
+++ b/EXOSIMS/Prototypes/Observatory.py
@@ -527,23 +527,23 @@ class Observatory(object):
 
         if os.path.exists(koPath):
             # keepout map already exists for parameters
-            print 'Loading cached keepout map file from %s' % koPath
+            self.vprint('Loading cached keepout map file from %s' % koPath)
             A = pickle.load(open(koPath, 'rb'))
-            print 'Keepout Map loaded from cache.'
+            self.vprint('Keepout Map loaded from cache.')
             koMap = A['koMap']
         else:
-            print 'Cached keepout map file not found at "%s".' % koPath
+            self.vprint('Cached keepout map file not found at "%s".' % koPath)
             # looping over all stars to generate map of when all stars are observable
-            print 'Starting keepout calculations for %s stars.' % TL.nStars
+            self.vprint('Starting keepout calculations for %s stars.' % TL.nStars)
             koMap = np.zeros([TL.nStars,len(koTimes)])
             for n in range(TL.nStars):
                 koMap[n,:] = self.keepout(TL,n,koTimes,False)
-                if not n % 50: print '   [%s / %s] completed.' % (n,TL.nStars)
+                if not n % 50: self.vprint('   [%s / %s] completed.' % (n,TL.nStars))
             A = {'koMap':koMap}
             with open(koPath, 'wb') as f:
                 pickle.dump(A, f)
-            print 'Keepout Map calculations finished'
-            print 'Keepout Map array stored in %r' % koPath
+            self.vprint('Keepout Map calculations finished')
+            self.vprint('Keepout Map array stored in %r' % koPath)
             
         return koMap,koTimes
     

--- a/EXOSIMS/Prototypes/Observatory.py
+++ b/EXOSIMS/Prototypes/Observatory.py
@@ -820,7 +820,7 @@ class Observatory(object):
                   'Pluto': 9,
                   'Sun': 10,
                   'Moon': 301}
-        assert bodies.has_key(bodyname), \
+        assert bodyname in bodies, \
                  "%s is not a recognized body name."%(bodyname)
         
         # julian day time
@@ -884,7 +884,7 @@ class Observatory(object):
             r_Earth = self.keplerplanet(currentTime, 'Earth')
             return r_Earth + self.moon_earth(currentTime)
         
-        assert self.planets.has_key(bodyname),\
+        assert bodyname in self.planets,\
                 "%s is not a recognized body name."%(bodyname)
         
         # find Julian centuries from J2000

--- a/EXOSIMS/Prototypes/Observatory.py
+++ b/EXOSIMS/Prototypes/Observatory.py
@@ -536,7 +536,8 @@ class Observatory(object):
         if os.path.exists(koPath):
             # keepout map already exists for parameters
             self.vprint('Loading cached keepout map file from %s' % koPath)
-            A = pickle.load(open(koPath, 'rb'))
+            with open(koPath, 'rb') as ff:
+                A = pickle.load(ff)
             self.vprint('Keepout Map loaded from cache.')
             koMap = A['koMap']
         else:

--- a/EXOSIMS/Prototypes/Observatory.py
+++ b/EXOSIMS/Prototypes/Observatory.py
@@ -154,7 +154,7 @@ class Observatory(object):
             self.vprint("Using static solar system ephemerides.")
         
         # populate outspec
-        for att in self.__dict__.keys():
+        for att in self.__dict__:
             if att not in ['vprint','_outspec']:
                 dat = self.__dict__[att]
                 self._outspec[att] = dat.value if isinstance(dat, u.Quantity) else dat
@@ -282,7 +282,7 @@ class Observatory(object):
         
         """
         
-        for att in self.__dict__.keys():
+        for att in self.__dict__:
             print('%s: %r' % (att, getattr(self, att)))
         
         return 'Observatory class object attributes'
@@ -1340,7 +1340,7 @@ class Observatory(object):
             
             """
             
-            for att in self.__dict__.keys():
+            for att in self.__dict__:
                 print('%s: %r' % (att, getattr(self, att)))
             
             return 'SolarEph class object attributes'

--- a/EXOSIMS/Prototypes/Observatory.py
+++ b/EXOSIMS/Prototypes/Observatory.py
@@ -522,7 +522,7 @@ class Observatory(object):
         extstr += '%s: ' % 'missionStart'     + str(missionStart)     + ' '
         extstr += '%s: ' % 'missionFinishAbs' + str(missionFinishAbs) + ' '
         extstr += '%s: ' % 'Name' + str(getattr(TL, 'Name')) + ' '
-        ext = hashlib.md5(extstr).hexdigest()
+        ext = hashlib.md5(extstr.encode('utf-8')).hexdigest()
         filename += ext
         koPath = os.path.join(self.cachedir, filename+'.komap')
         

--- a/EXOSIMS/Prototypes/Observatory.py
+++ b/EXOSIMS/Prototypes/Observatory.py
@@ -13,12 +13,14 @@ except:
     import pickle
 import hashlib
 import os
-import urllib
 import sys
 
 # Python 3 compatibility:
 if sys.version_info[0] > 2:
     xrange = range
+    from urllib.request import urlretrieve
+else:
+    from urllib import urlretrieve
 
 class Observatory(object):
     """Observatory class template
@@ -177,7 +179,8 @@ class Observatory(object):
                     spk_on_web = 'https://naif.jpl.nasa.gov/pub/naif/generic_kernels/spk/planets/de432s.bsp'
                     self.vprint("Fetching planetary ephemeris from %s to %s" % (spk_on_web, spkpath))
                     try:
-                        urllib.urlretrieve(spk_on_web, spkpath)
+                        # urllib.urlretrieve(spk_on_web, spkpath)
+                        urlretrieve(spk_on_web, spkpath)
                     except:
                         # Note: the SPK.open() below will fail in this case
                         self.vprint("Error: Remote fetch failed. Fetch manually or see install instructions.")

--- a/EXOSIMS/Prototypes/OpticalSystem.py
+++ b/EXOSIMS/Prototypes/OpticalSystem.py
@@ -224,7 +224,7 @@ class OpticalSystem(object):
         self._outspec['scienceInstruments'] = []
         for ninst, inst in enumerate(self.scienceInstruments):
             assert isinstance(inst, dict), "Science instruments must be defined as dicts."
-            assert inst.has_key('name') and isinstance(inst['name'], basestring), \
+            assert 'name' in inst and isinstance(inst['name'], basestring), \
                     "All science instruments must have key name."
             # populate with values that may be filenames (interpolants)
             inst['QE'] = inst.get('QE', QE)
@@ -293,7 +293,7 @@ class OpticalSystem(object):
         for nsyst,syst in enumerate(self.starlightSuppressionSystems):
             assert isinstance(syst,dict),\
                     "Starlight suppression systems must be defined as dicts."
-            assert syst.has_key('name') and isinstance(syst['name'],basestring),\
+            assert 'name' in syst and isinstance(syst['name'],basestring),\
                     "All starlight suppression systems must have key name."
             # populate with values that may be filenames (interpolants)
             syst['occ_trans'] = syst.get('occ_trans', occ_trans)
@@ -372,7 +372,7 @@ class OpticalSystem(object):
         self._outspec['observingModes'] = []
         for nmode, mode in enumerate(self.observingModes):
             assert isinstance(mode, dict), "Observing modes must be defined as dicts."
-            assert mode.has_key('instName') and mode.has_key('systName'), \
+            assert 'instName' in mode and 'systName' in mode, \
                     "All observing modes must have key instName and systName."
             assert np.any([mode['instName'] == inst['name'] for inst in \
                     self.scienceInstruments]), "The mode's instrument name " \

--- a/EXOSIMS/Prototypes/OpticalSystem.py
+++ b/EXOSIMS/Prototypes/OpticalSystem.py
@@ -8,6 +8,11 @@ import astropy.units as u
 import astropy.io.fits as fits
 import scipy.interpolate
 import scipy.optimize
+import sys
+
+# Python 3 compatibility:
+if sys.version_info[0] > 2:
+    basestring = str
 
 class OpticalSystem(object):
     """Optical System class template

--- a/EXOSIMS/Prototypes/OpticalSystem.py
+++ b/EXOSIMS/Prototypes/OpticalSystem.py
@@ -284,7 +284,7 @@ class OpticalSystem(object):
             inst['fnumber'] = float(inst['focal']/self.pupilDiam)
             
             # populate detector specifications to outspec
-            for att in inst.keys():
+            for att in inst:
                 if att not in ['QE']:
                     dat = inst[att]
                     self._outspec['scienceInstruments'][ninst][att] = dat.value \
@@ -358,7 +358,7 @@ class OpticalSystem(object):
             syst['ohTime'] = float(syst.get('ohTime', ohTime))*u.d  # overhead time
             
             # populate system specifications to outspec
-            for att in syst.keys():
+            for att in syst:
                 if att not in ['occ_trans', 'core_thruput', 'core_contrast',
                         'core_mean_intensity', 'core_area', 'PSF']:
                     dat = syst[att]
@@ -454,7 +454,7 @@ class OpticalSystem(object):
         assert self.IWA < self.OWA, "Fundamental IWA must be smaller that the OWA."
         
         # populate outspec with all OpticalSystem scalar attributes
-        for att in self.__dict__.keys():
+        for att in self.__dict__:
             if att not in ['vprint', 'F0', 'scienceInstruments', 
                     'starlightSuppressionSystems', 'observingModes','_outspec']:
                 dat = self.__dict__[att]
@@ -468,7 +468,7 @@ class OpticalSystem(object):
         
         """
         
-        for att in self.__dict__.keys():
+        for att in self.__dict__:
             print('%s: %r' % (att, getattr(self, att)))
         
         return 'Optical System class object attributes'

--- a/EXOSIMS/Prototypes/OpticalSystem.py
+++ b/EXOSIMS/Prototypes/OpticalSystem.py
@@ -415,11 +415,11 @@ class OpticalSystem(object):
         
         # check for only one detection mode
         allModes = self.observingModes
-        detModes = filter(lambda mode: mode['detectionMode'] == True, allModes)
+        detModes = list(filter(lambda mode: mode['detectionMode'] == True, allModes))
         assert len(detModes) <= 1, "More than one detection mode specified."
         # if not specified, default detection mode is first imager mode
         if len(detModes) == 0:
-            imagerModes = filter(lambda mode: 'imag' in mode['inst']['name'], allModes)
+            imagerModes = list(filter(lambda mode: 'imag' in mode['inst']['name'], allModes))
             if imagerModes:
                 imagerModes[0]['detectionMode'] = True
             # if no imager mode, default detection mode is first observing mode
@@ -431,7 +431,7 @@ class OpticalSystem(object):
         try:
             self.WA0 = float(WA0)*u.arcsec
         except TypeError:
-            mode = filter(lambda mode: mode['detectionMode'] == True, self.observingModes)[0]
+            mode = list(filter(lambda mode: mode['detectionMode'] == True, self.observingModes))[0]
             self.WA0 = 2.*mode['IWA'] if np.isinf(mode['OWA']) else (mode['IWA'] + mode['OWA'])/2.
         
         # populate fundamental IWA and OWA as required
@@ -723,7 +723,7 @@ class OpticalSystem(object):
         """
         
         # select detection mode
-        mode = filter(lambda mode: mode['detectionMode'] == True, self.observingModes)[0]
+        mode = list(filter(lambda mode: mode['detectionMode'] == True, self.observingModes))[0]
         
         # define attributes for integration time calculation
         sInds = np.arange(TL.nStars)

--- a/EXOSIMS/Prototypes/PlanetPhysicalModel.py
+++ b/EXOSIMS/Prototypes/PlanetPhysicalModel.py
@@ -42,7 +42,7 @@ class PlanetPhysicalModel(object):
         When the command 'print' is used on the Planet Physical Model object, 
         this method will return the values contained in the object"""
         
-        for att in self.__dict__.keys():
+        for att in self.__dict__:
             print('%s: %r' % (att, getattr(self, att)))
         
         return 'Planet Physical Model class object attributes'

--- a/EXOSIMS/Prototypes/PlanetPopulation.py
+++ b/EXOSIMS/Prototypes/PlanetPopulation.py
@@ -104,7 +104,7 @@ class PlanetPopulation(object):
         self.pfromRp = False
         
         # populate all attributes to outspec
-        for att in self.__dict__.keys():
+        for att in self.__dict__:
             if att not in ['vprint','_outspec']:
                 dat = copy.copy(self.__dict__[att])
                 self._outspec[att] = dat.value if isinstance(dat, u.Quantity) else dat
@@ -146,7 +146,7 @@ class PlanetPopulation(object):
         When the command 'print' is used on the Planet Population object, this 
         method will print the attribute values contained in the object"""
         
-        for att in self.__dict__.keys():
+        for att in self.__dict__:
             print('%s: %r' % (att, getattr(self, att)))
         
         return 'Planet Population class object attributes'

--- a/EXOSIMS/Prototypes/PostProcessing.py
+++ b/EXOSIMS/Prototypes/PostProcessing.py
@@ -8,6 +8,11 @@ import os
 import scipy.interpolate
 import numbers
 from astropy.io import fits
+import sys
+
+# Python 3 compatibility:
+if sys.version_info[0] > 2:
+    basestring = str
 
 class PostProcessing(object):
     """Post Processing class template

--- a/EXOSIMS/Prototypes/PostProcessing.py
+++ b/EXOSIMS/Prototypes/PostProcessing.py
@@ -66,7 +66,8 @@ class PostProcessing(object):
         if isinstance(ppFact, basestring):
             pth = os.path.normpath(os.path.expandvars(ppFact))
             assert os.path.isfile(pth), "%s is not a valid file."%pth
-            dat = fits.open(pth)[0].data
+            with fits.open(pth) as ff:
+                dat = ff[0].data
             assert len(dat.shape) == 2 and 2 in dat.shape, \
                     "Wrong post-processing gain data shape."
             WA, G = (dat[0], dat[1]) if dat.shape[0] == 2 else (dat[:,0], dat[:,1])
@@ -85,7 +86,8 @@ class PostProcessing(object):
         if isinstance(FAdMag0, basestring):
             pth = os.path.normpath(os.path.expandvars(FAdMag0))
             assert os.path.isfile(pth), "%s is not a valid file."%pth
-            dat = fits.open(pth)[0].data
+            with fits.open(pth) as ff:
+                dat = ff[0].data
             assert len(dat.shape) == 2 and 2 in dat.shape, \
                     "Wrong FAdMag0 data shape."
             WA, G = (dat[0], dat[1]) if dat.shape[0] == 2 else (dat[:,0], dat[:,1])

--- a/EXOSIMS/Prototypes/PostProcessing.py
+++ b/EXOSIMS/Prototypes/PostProcessing.py
@@ -98,7 +98,7 @@ class PostProcessing(object):
             self.FAdMag0 = lambda s, G=float(FAdMag0): G
         
         # populate outspec
-        for att in self.__dict__.keys():
+        for att in self.__dict__:
             if att not in ['vprint', 'ppFact', 'FAdMag0','_outspec']:
                 dat = self.__dict__[att]
                 self._outspec[att] = dat.value if isinstance(dat, u.Quantity) else dat
@@ -118,7 +118,7 @@ class PostProcessing(object):
         
         """
         
-        for att in self.__dict__.keys():
+        for att in self.__dict__:
             print('%s: %r' % (att, getattr(self, att)))
         
         return 'Post Processing class object attributes'

--- a/EXOSIMS/Prototypes/SimulatedUniverse.py
+++ b/EXOSIMS/Prototypes/SimulatedUniverse.py
@@ -161,7 +161,7 @@ class SimulatedUniverse(object):
         
         """
         
-        for att in self.__dict__.keys():
+        for att in self.__dict__:
             print('%s: %r' % (att, getattr(self, att)))
         
         return 'Simulated Universe class object attributes'

--- a/EXOSIMS/Prototypes/SimulatedUniverse.py
+++ b/EXOSIMS/Prototypes/SimulatedUniverse.py
@@ -383,9 +383,9 @@ class SimulatedUniverse(object):
         num += len(np.where(mask == True)[0])
         betas[mask] = np.pi/2.
         if num > 0:
-            print('***Warning***')
-            print('{} planets out of {} could not be set to phase angle {} radians.'.format(num,self.nPlans,beta))
-            print('These planets are set to quadrature (phase angle pi/2)')
+            self.vprint('***Warning***')
+            self.vprint('{} planets out of {} could not be set to phase angle {} radians.'.format(num,self.nPlans,beta))
+            self.vprint('These planets are set to quadrature (phase angle pi/2)')
         
         # solve for true anomaly
         nu = np.arcsin(np.cos(betas)/np.sin(I)) - w

--- a/EXOSIMS/Prototypes/StarCatalog.py
+++ b/EXOSIMS/Prototypes/StarCatalog.py
@@ -116,7 +116,7 @@ class StarCatalog(object):
         
         """
         
-        for att in self.__dict__.keys():
+        for att in self.__dict__:
             print('%s: %r' % (att, getattr(self, att)))
         
         return 'Star Catalog class object attributes'

--- a/EXOSIMS/Prototypes/StarCatalog.py
+++ b/EXOSIMS/Prototypes/StarCatalog.py
@@ -102,7 +102,7 @@ class StarCatalog(object):
         self.BV = np.zeros(ntargs)                              # B-V Johnson magnitude
         self.MV = np.zeros(ntargs)                              # absolute V magnitude 
         self.BC = np.zeros(ntargs)                              # bolometric correction
-        self.L = np.zeros(ntargs)                               # stellar luminosity in ln(SolLum)
+        self.L = np.ones(ntargs)                               # stellar luminosity in ln(SolLum)
         self.Binary_Cut = np.zeros(ntargs, dtype=bool)          # binary closer than 10 arcsec
         
         # populate outspecs

--- a/EXOSIMS/Prototypes/SurveySimulation.py
+++ b/EXOSIMS/Prototypes/SurveySimulation.py
@@ -128,7 +128,7 @@ class SurveySimulation(object):
                 raise
             
             # modules array must be present
-            if 'modules' not in specs.keys():
+            if 'modules' not in specs:
                 raise ValueError("No modules field found in script.")
         
         # load the vprint function (same line in all prototype module constructors)
@@ -149,7 +149,7 @@ class SurveySimulation(object):
 
         # if any of the modules is a string, assume that they are all strings 
         # and we need to initalize
-        if isinstance(next(iter(specs['modules'])), basestring):
+        if isinstance(next(iter(specs['modules'].values())), basestring):
             
             # import desired module names (prototype or specific)
             self.SimulatedUniverse = get_module(specs['modules']['SimulatedUniverse'],
@@ -187,10 +187,10 @@ class SurveySimulation(object):
             
             # ensure that you have the minimal set
             for modName in neededObjMods:
-                if modName not in specs['modules'].keys():
+                if modName not in specs['modules']:
                     raise ValueError("%s module is required but was not provided."%modName)
             
-            for modName in specs['modules'].keys():
+            for modName in specs['modules']:
                 assert (specs['modules'][modName]._modtype == modName), \
                         "Provided instance of %s has incorrect modtype."%modName
 
@@ -333,7 +333,7 @@ class SurveySimulation(object):
         
         """
         
-        for att in self.__dict__.keys():
+        for att in self.__dict__:
             print('%s: %r' % (att, getattr(self, att)))
         
         return 'Survey Simulation class object attributes'

--- a/EXOSIMS/Prototypes/SurveySimulation.py
+++ b/EXOSIMS/Prototypes/SurveySimulation.py
@@ -750,7 +750,7 @@ class SurveySimulation(object):
         Obs = self.Observatory
         TK = self.TimeKeeping
         allModes = OS.observingModes
-        mode = filter(lambda mode: mode['detectionMode'] == True, allModes)[0]
+        mode = list(filter(lambda mode: mode['detectionMode'] == True, allModes))[0]
         maxIntTimeOBendTime, maxIntTimeExoplanetObsTime, maxIntTimeMissionLife = TK.get_ObsDetectionMaxIntTime(Obs, mode)
         maxIntTime = min(maxIntTimeOBendTime, maxIntTimeExoplanetObsTime, maxIntTimeMissionLife)#Maximum intTime allowed
         intTimes2 = self.calc_targ_intTime(sInd, TK.currentTimeAbs.copy(), mode)

--- a/EXOSIMS/Prototypes/SurveySimulation.py
+++ b/EXOSIMS/Prototypes/SurveySimulation.py
@@ -12,6 +12,10 @@ import time
 import json, os.path, copy, re, inspect, subprocess
 import hashlib
 
+# Python 3 compatibility:
+if sys.version_info[0] > 2:
+    basestring = str
+
 Logger = logging.getLogger(__name__)
 
 class SurveySimulation(object):

--- a/EXOSIMS/Prototypes/SurveySimulation.py
+++ b/EXOSIMS/Prototypes/SurveySimulation.py
@@ -239,7 +239,7 @@ class SurveySimulation(object):
         OS = self.OpticalSystem
         TL = self.TargetList
         SU = self.SimulatedUniverse
-        mode = filter(lambda mode: mode['detectionMode'] == True, OS.observingModes)[0]
+        mode = list(filter(lambda mode: mode['detectionMode'] == True, OS.observingModes))[0]
 
         if dMagint is None:
             dMagint = Comp.dMagLim 
@@ -297,7 +297,7 @@ class SurveySimulation(object):
 
         # choose observing modes selected for detection (default marked with a flag)
         allModes = OS.observingModes
-        det_mode = filter(lambda mode: mode['detectionMode'] == True, allModes)[0]
+        det_mode = list(filter(lambda mode: mode['detectionMode'] == True, allModes))[0]
         self.mode = det_mode
 
         # Precalculating intTimeFilter
@@ -356,9 +356,9 @@ class SurveySimulation(object):
         
         # choose observing modes selected for detection (default marked with a flag)
         allModes = OS.observingModes
-        det_mode = filter(lambda mode: mode['detectionMode'] == True, allModes)[0]
+        det_mode = list(filter(lambda mode: mode['detectionMode'] == True, allModes))[0]
         # and for characterization (default is first spectro/IFS mode)
-        spectroModes = filter(lambda mode: 'spec' in mode['inst']['name'], allModes)
+        spectroModes = list(filter(lambda mode: 'spec' in mode['inst']['name'], allModes))
         if np.any(spectroModes):
             char_mode = spectroModes[0]
         # if no spectro mode, default char mode is first observing mode

--- a/EXOSIMS/Prototypes/SurveySimulation.py
+++ b/EXOSIMS/Prototypes/SurveySimulation.py
@@ -149,7 +149,7 @@ class SurveySimulation(object):
 
         # if any of the modules is a string, assume that they are all strings 
         # and we need to initalize
-        if isinstance(specs['modules'].itervalues().next(), basestring):
+        if isinstance(next(iter(specs['modules'])), basestring):
             
             # import desired module names (prototype or specific)
             self.SimulatedUniverse = get_module(specs['modules']['SimulatedUniverse'],

--- a/EXOSIMS/Prototypes/SurveySimulation.py
+++ b/EXOSIMS/Prototypes/SurveySimulation.py
@@ -1790,7 +1790,7 @@ class SurveySimulation(object):
         cachefname += str(tmp2)#Planet Pop
         cachefname += str(tmp1)#Planet Physical Model
         for mod in mods: cachefname += self.modules[mod].__module__.split(".")[-1]#add module name to end of cachefname?
-        cachefname += hashlib.md5(str(self.TargetList.Name)+str(self.TargetList.tint0.to(u.d).value)).hexdigest()#turn cachefname into hashlib
+        cachefname += hashlib.md5((str(self.TargetList.Name)+str(self.TargetList.tint0.to(u.d).value)).encode('utf-8')).hexdigest()#turn cachefname into hashlib
         # fileloc = os.path.split(inspect.getfile(self.__class__))[0]
         cachefname = os.path.join(self.cachedir,cachefname+os.extsep)#join into filepath and fname
         #Needs file terminator (.starkt0, .t0, etc) appended done by each individual use case.

--- a/EXOSIMS/Prototypes/TargetList.py
+++ b/EXOSIMS/Prototypes/TargetList.py
@@ -513,7 +513,7 @@ class TargetList(object):
         
         """
         
-        spec = np.array(map(str, self.Spec))
+        spec = np.array(list(map(str, self.Spec)))
         iF = np.where(np.core.defchararray.startswith(spec, 'F'))[0]
         iG = np.where(np.core.defchararray.startswith(spec, 'G'))[0]
         iK = np.where(np.core.defchararray.startswith(spec, 'K'))[0]

--- a/EXOSIMS/Prototypes/TargetList.py
+++ b/EXOSIMS/Prototypes/TargetList.py
@@ -120,7 +120,7 @@ class TargetList(object):
             'This TargetList cannot use KnownRVPlanets'
         
         # populate outspec
-        for att in self.__dict__.keys():
+        for att in self.__dict__:
             if att not in ['vprint','_outspec']:
                 dat = self.__dict__[att]
                 self._outspec[att] = dat.value if isinstance(dat, u.Quantity) else dat
@@ -184,7 +184,7 @@ class TargetList(object):
         
         """
         
-        for att in self.__dict__.keys():
+        for att in self.__dict__:
             print('%s: %r' % (att, getattr(self, att)))
         
         return 'Target List class object attributes'

--- a/EXOSIMS/Prototypes/TargetList.py
+++ b/EXOSIMS/Prototypes/TargetList.py
@@ -142,7 +142,7 @@ class TargetList(object):
 
         #if specs contains a completeness_spec then we are going to generate separate instances
         #of planet population and planet physical model for completeness and for the rest of the sim
-        if specs.has_key('completeness_specs'):
+        if 'completeness_specs' in specs:
             self.PlanetPopulation = get_module(specs['modules']['PlanetPopulation'],'PlanetPopulation')(**specs)
             self.PlanetPhysicalModel = self.PlanetPopulation.PlanetPhysicalModel
         else:

--- a/EXOSIMS/Prototypes/TargetList.py
+++ b/EXOSIMS/Prototypes/TargetList.py
@@ -444,13 +444,13 @@ class TargetList(object):
         for att in self.catalog_atts:
             if getattr(self, att).shape[0] == 0:
                 pass
-            elif type(getattr(self, att)[0]) == str:
+            elif (type(getattr(self, att)[0]) == str) or (type(getattr(self, att)[0]) == bytes):
                 # FIXME: intent here unclear: 
                 #   note float('nan') is an IEEE NaN, getattr(.) is a str, and != on NaNs is special
                 i = np.where(getattr(self, att) != float('nan'))[0]
                 self.revise_lists(i)
             # exclude non-numerical types
-            elif type(getattr(self, att)[0]) not in (np.unicode_, np.string_, np.bool_):
+            elif type(getattr(self, att)[0]) not in (np.unicode_, np.string_, np.bool_, bytes):
                 if att == 'coords':
                     i1 = np.where(~np.isnan(self.coords.ra.to('deg').value))[0]
                     i2 = np.where(~np.isnan(self.coords.dec.to('deg').value))[0]

--- a/EXOSIMS/Prototypes/TimeKeeping.py
+++ b/EXOSIMS/Prototypes/TimeKeeping.py
@@ -151,7 +151,7 @@ class TimeKeeping(object):
 
             if os.path.isfile(schedulefname):  # Check if a mission schedule is manually specified
                 self.vprint("Loading Manual Schedule from %s"%missionSchedule)
-                with open(schedulefname, 'rb') as f:  # load csv file
+                with open(schedulefname, 'r') as f:  # load csv file
                     lines = csv.reader(f,delimiter=',')
                     self.vprint('The manual Schedule is:')
                     for line in lines:

--- a/EXOSIMS/Prototypes/TimeKeeping.py
+++ b/EXOSIMS/Prototypes/TimeKeeping.py
@@ -101,7 +101,7 @@ class TimeKeeping(object):
         self.exoplanetObsTime = 0*u.day
         
         # populate outspec
-        for att in self.__dict__.keys():
+        for att in self.__dict__:
             if att not in ['vprint','_outspec']:
                 dat = self.__dict__[att]
                 self._outspec[att] = dat.value if isinstance(dat,(u.Quantity,Time)) else dat
@@ -112,7 +112,7 @@ class TimeKeeping(object):
         When the command 'print' is used on the TimeKeeping object, this 
         method prints the values contained in the object."""
         
-        for att in self.__dict__.keys():
+        for att in self.__dict__:
             print('%s: %r' % (att, getattr(self, att)))
         
         return 'TimeKeeping instance at %.6f days' % self.currentTimeNorm.to('day').value

--- a/EXOSIMS/Prototypes/ZodiacalLight.py
+++ b/EXOSIMS/Prototypes/ZodiacalLight.py
@@ -8,6 +8,11 @@ try:
     import cPickle as pickle
 except:
     import pickle
+import sys
+
+# Python 3 compatibility:
+if sys.version_info[0] > 2:
+    xrange = range
 
 class ZodiacalLight(object):
     """Zodiacal Light class template

--- a/EXOSIMS/Prototypes/ZodiacalLight.py
+++ b/EXOSIMS/Prototypes/ZodiacalLight.py
@@ -62,7 +62,7 @@ class ZodiacalLight(object):
         assert self.varEZ >= 0, "Exozodi variation must be >= 0"
         
         # populate outspec
-        for att in self.__dict__.keys():
+        for att in self.__dict__:
             if att not in ['vprint','_outspec']:
                 dat = self.__dict__[att]
                 self._outspec[att] = dat.value if isinstance(dat, u.Quantity) else dat
@@ -75,7 +75,7 @@ class ZodiacalLight(object):
         
         """
         
-        for att in self.__dict__.keys():
+        for att in self.__dict__:
             print('%s: %r' % (att, getattr(self, att)))
         
         return 'Zodiacal Light class object attributes'

--- a/EXOSIMS/StarCatalog/EXOCAT1.py
+++ b/EXOSIMS/StarCatalog/EXOCAT1.py
@@ -66,8 +66,8 @@ class EXOCAT1(StarCatalog):
         self.L = data['st_lbol'].data
         
         # list of non-astropy attributes
-        self.Name = data['hip_name']
-        self.Spec = data['st_spttype']
+        self.Name = data['hip_name'].astype(str)
+        self.Spec = data['st_spttype'].astype(str)
         self.Vmag = data['st_vmag']
         self.Jmag = data['st_j2m']
         self.Hmag = data['st_h2m']

--- a/EXOSIMS/StarCatalog/SIMBAD300Catalog.py
+++ b/EXOSIMS/StarCatalog/SIMBAD300Catalog.py
@@ -21,12 +21,12 @@ class SIMBAD300Catalog(SIMBADCatalog):
         # check if given filename exists as .pkl file already
         if os.path.exists(pklpath):
             self.populatepkl(pklpath, **specs)
-            print 'Loaded %s.pkl star catalog'%filename
+            self.vprint('Loaded %s.pkl star catalog'%filename)
         # check if given filename exists as a .mat file but not .pkl file
         elif os.path.exists(matpath):
             self.SIMBAD_mat2pkl(matpath, pklpath)
             self.populatepkl(pklpath, **specs)
-            print 'Loaded %s.mat star catalog'%filename
+            self.vprint('Loaded %s.mat star catalog'%filename)
         # otherwise print error
         else:
-            print 'Could not load SIMBAD300 star catalog'
+            self.vprint('Could not load SIMBAD300 star catalog')

--- a/EXOSIMS/StarCatalog/SIMBADCatalog.py
+++ b/EXOSIMS/StarCatalog/SIMBADCatalog.py
@@ -51,10 +51,10 @@ class SIMBADCatalog(StarCatalog):
                 
                 success = True
             else:
-                print "pickled dictionary file %s must contain key 'Name'"%pklpath
+                self.vprint("pickled dictionary file %s must contain key 'Name'"%pklpath)
                 success = False
         else:
-            print 'Star catalog pickled dictionary file %s not in StarCatalog directory'%pklpath
+            self.vprint('Star catalog pickled dictionary file %s not in StarCatalog directory'%pklpath)
             success = False
         
         return success
@@ -107,7 +107,7 @@ class SIMBADCatalog(StarCatalog):
             pickle.dump(y, open(pklpath, 'wb'))
             success = True
         else:
-            print '%s does not exist in StarCatalog directory'%matpath
+            self.vprint('%s does not exist in StarCatalog directory'%matpath)
             success = False
         
         return success

--- a/EXOSIMS/StarCatalog/SIMBADCatalog.py
+++ b/EXOSIMS/StarCatalog/SIMBADCatalog.py
@@ -44,13 +44,13 @@ class SIMBADCatalog(StarCatalog):
                 ntargs = len(x['Name'])
                 StarCatalog.__init__(self, ntargs=ntargs, **specs)
                 
-                for att in x.keys():
+                for att in x:
                     # list of astropy attributes
                     if att in ('dist', 'parx', 'pmra', 'pmdec', 'rv'):
                         unit = getattr(self,att).unit
                         setattr(self, att, np.array(x[att])*unit)
                     # list of non-astropy attributes
-                    elif att in self.__dict__.keys():
+                    elif att in self.__dict__:
                         setattr(self, att, np.array(x[att]))
                 # astropy SkyCoord object
                 self.coords = SkyCoord(x['radeg'], x['decdeg'], x['dist'], 

--- a/EXOSIMS/StarCatalog/SIMBADCatalog.py
+++ b/EXOSIMS/StarCatalog/SIMBADCatalog.py
@@ -6,6 +6,11 @@ from scipy.io import loadmat
 from astropy.coordinates import SkyCoord
 import numpy as np
 import astropy.units as u
+import sys
+
+# Python 3 compatibility:
+if sys.version_info[0] > 2:
+    xrange = range
 
 class SIMBADCatalog(StarCatalog):
     """SIMBAD Catalog class

--- a/EXOSIMS/StarCatalog/SIMBADCatalog.py
+++ b/EXOSIMS/StarCatalog/SIMBADCatalog.py
@@ -39,7 +39,8 @@ class SIMBADCatalog(StarCatalog):
         """
         
         if os.path.exists(pklpath):
-            x = pickle.load(open(pklpath, 'rb'))
+            with open(pklpath, 'rb') as f:
+                x = pickle.load(f)
             if 'Name' in x:
                 ntargs = len(x['Name'])
                 StarCatalog.__init__(self, ntargs=ntargs, **specs)
@@ -111,7 +112,8 @@ class SIMBADCatalog(StarCatalog):
                 else:
                     y[mat2pkl[field]] = getattr(x, field).tolist()
             # store pickled y dictionary in file
-            pickle.dump(y, open(pklpath, 'wb'))
+            with open(pklpath, 'wb') as f:
+                pickle.dump(y, f)
             success = True
         else:
             self.vprint('%s does not exist in StarCatalog directory'%matpath)

--- a/EXOSIMS/StarCatalog/SIMBADCatalog.py
+++ b/EXOSIMS/StarCatalog/SIMBADCatalog.py
@@ -1,11 +1,13 @@
 # -*- coding: utf-8 -*-
 from EXOSIMS.Prototypes.StarCatalog import StarCatalog
 import os
-import cPickle as pickle
+try:
+    import cPickle as pickle
+except ImportError:
+    import pickle
 from scipy.io import loadmat
 from astropy.coordinates import SkyCoord
 import numpy as np
-import astropy.units as u
 import sys
 
 # Python 3 compatibility:

--- a/EXOSIMS/SurveyEnsemble/IPClusterEnsemble.py
+++ b/EXOSIMS/SurveyEnsemble/IPClusterEnsemble.py
@@ -13,7 +13,10 @@ import EXOSIMS
 import EXOSIMS.MissionSim
 import os
 import os.path
-import cPickle
+try:
+    import cPickle as pickle
+except ImportError:
+    import pickle
 import random
 import traceback
 
@@ -34,7 +37,7 @@ class IPClusterEnsemble(SurveyEnsemble):
         self.dview = self.rc[:]
         self.dview.block = True
         with self.dview.sync_imports(): import EXOSIMS, EXOSIMS.util.get_module, \
-                os, os.path, time, random, cPickle, traceback
+                os, os.path, time, random, pickle, traceback
         if 'logger' in specs:
             specs.pop('logger')
         if 'seed' in specs:

--- a/EXOSIMS/SurveyEnsemble/IPClusterEnsemble.py
+++ b/EXOSIMS/SurveyEnsemble/IPClusterEnsemble.py
@@ -35,9 +35,9 @@ class IPClusterEnsemble(SurveyEnsemble):
         self.dview.block = True
         with self.dview.sync_imports(): import EXOSIMS, EXOSIMS.util.get_module, \
                 os, os.path, time, random, cPickle, traceback
-        if specs.has_key('logger'):
+        if 'logger' in specs:
             specs.pop('logger')
-        if specs.has_key('seed'):
+        if 'seed' in specs:
             specs.pop('seed')
         self.dview.push(dict(specs=specs))
         self.vprint("Building SurveySimulation object on all workers.")

--- a/EXOSIMS/SurveySimulation/SLSQPScheduler.py
+++ b/EXOSIMS/SurveySimulation/SLSQPScheduler.py
@@ -43,7 +43,7 @@ class SLSQPScheduler(SurveySimulation):
 
 
         #some global defs
-        self.detmode = filter(lambda mode: mode['detectionMode'] == True, self.OpticalSystem.observingModes)[0]
+        self.detmode = list(filter(lambda mode: mode['detectionMode'] == True, self.OpticalSystem.observingModes))[0]
         self.ohTimeTot = self.Observatory.settlingTime + self.detmode['syst']['ohTime']
         self.maxTime = self.TimeKeeping.missionLife*self.TimeKeeping.missionPortion
 

--- a/EXOSIMS/SurveySimulation/SLSQPSchedulerA.py
+++ b/EXOSIMS/SurveySimulation/SLSQPSchedulerA.py
@@ -43,7 +43,7 @@ class SLSQPSchedulerA(SurveySimulation):
 
 
         #some global defs
-        self.detmode = filter(lambda mode: mode['detectionMode'] == True, self.OpticalSystem.observingModes)[0]
+        self.detmode = list(filter(lambda mode: mode['detectionMode'] == True, self.OpticalSystem.observingModes))[0]
         self.ohTimeTot = self.Observatory.settlingTime + self.detmode['syst']['ohTime']
         self.maxTime = self.TimeKeeping.missionLife*self.TimeKeeping.missionPortion
 

--- a/EXOSIMS/SurveySimulation/SLSQPSchedulerA.py
+++ b/EXOSIMS/SurveySimulation/SLSQPSchedulerA.py
@@ -298,7 +298,7 @@ class SLSQPSchedulerA(SurveySimulation):
         sInd = np.random.choice(sInds[comps == max(comps)])
         
         if self.t0[sInd] < 1.0*u.s:
-		sInd = None
+            sInd = None
 
         return sInd, None
 

--- a/EXOSIMS/SurveySimulation/SLSQPSchedulerB.py
+++ b/EXOSIMS/SurveySimulation/SLSQPSchedulerB.py
@@ -43,7 +43,7 @@ class SLSQPSchedulerB(SurveySimulation):
 
 
         #some global defs
-        self.detmode = filter(lambda mode: mode['detectionMode'] == True, self.OpticalSystem.observingModes)[0]
+        self.detmode = list(filter(lambda mode: mode['detectionMode'] == True, self.OpticalSystem.observingModes))[0]
         self.ohTimeTot = self.Observatory.settlingTime + self.detmode['syst']['ohTime']
         self.maxTime = self.TimeKeeping.missionLife*self.TimeKeeping.missionPortion
 

--- a/EXOSIMS/SurveySimulation/SLSQPSchedulerC.py
+++ b/EXOSIMS/SurveySimulation/SLSQPSchedulerC.py
@@ -35,7 +35,7 @@ class SLSQPSchedulerC(SurveySimulation):
         SurveySimulation.__init__(self, **specs)
 
         #Calculate fZmax
-        self.valfZmax, self.absTimefZmax = self.ZodiacalLight.calcfZmax(np.arange(self.TargetList.nStars), self.Observatory, self.TargetList, self.TimeKeeping, filter(lambda mode: mode['detectionMode'] == True, self.OpticalSystem.observingModes)[0], self.cachefname)
+        self.valfZmax, self.absTimefZmax = self.ZodiacalLight.calcfZmax(np.arange(self.TargetList.nStars), self.Observatory, self.TargetList, self.TimeKeeping, list(filter(lambda mode: mode['detectionMode'] == True, self.OpticalSystem.observingModes))[0], self.cachefname)
 
         assert isinstance(staticOptTimes, bool), 'staticOptTimes must be boolean.'
         self.staticOptTimes = staticOptTimes
@@ -46,7 +46,7 @@ class SLSQPSchedulerC(SurveySimulation):
 
 
         #some global defs
-        self.detmode = filter(lambda mode: mode['detectionMode'] == True, self.OpticalSystem.observingModes)[0]
+        self.detmode = list(filter(lambda mode: mode['detectionMode'] == True, self.OpticalSystem.observingModes))[0]
         self.ohTimeTot = self.Observatory.settlingTime + self.detmode['syst']['ohTime']
         self.maxTime = self.TimeKeeping.missionLife*self.TimeKeeping.missionPortion
 

--- a/EXOSIMS/SurveySimulation/SLSQPSchedulerD.py
+++ b/EXOSIMS/SurveySimulation/SLSQPSchedulerD.py
@@ -35,7 +35,7 @@ class SLSQPSchedulerD(SurveySimulation):
         SurveySimulation.__init__(self, **specs)
 
         #Calculate fZmax
-        self.valfZmax, self.absTimefZmax = self.ZodiacalLight.calcfZmax(np.arange(self.TargetList.nStars), self.Observatory, self.TargetList, self.TimeKeeping, filter(lambda mode: mode['detectionMode'] == True, self.OpticalSystem.observingModes)[0], self.cachefname)
+        self.valfZmax, self.absTimefZmax = self.ZodiacalLight.calcfZmax(np.arange(self.TargetList.nStars), self.Observatory, self.TargetList, self.TimeKeeping, list(filter(lambda mode: mode['detectionMode'] == True, self.OpticalSystem.observingModes))[0], self.cachefname)
 
         assert isinstance(staticOptTimes, bool), 'staticOptTimes must be boolean.'
         self.staticOptTimes = staticOptTimes
@@ -46,7 +46,7 @@ class SLSQPSchedulerD(SurveySimulation):
 
 
         #some global defs
-        self.detmode = filter(lambda mode: mode['detectionMode'] == True, self.OpticalSystem.observingModes)[0]
+        self.detmode = list(filter(lambda mode: mode['detectionMode'] == True, self.OpticalSystem.observingModes))[0]
         self.ohTimeTot = self.Observatory.settlingTime + self.detmode['syst']['ohTime']
         self.maxTime = self.TimeKeeping.missionLife*self.TimeKeeping.missionPortion
 

--- a/EXOSIMS/SurveySimulation/SLSQPSchedulerE.py
+++ b/EXOSIMS/SurveySimulation/SLSQPSchedulerE.py
@@ -35,7 +35,7 @@ class SLSQPSchedulerE(SurveySimulation):
         SurveySimulation.__init__(self, **specs)
 
         #Calculate fZmax
-        self.valfZmax, self.absTimefZmax = self.ZodiacalLight.calcfZmax(np.arange(self.TargetList.nStars), self.Observatory, self.TargetList, self.TimeKeeping, filter(lambda mode: mode['detectionMode'] == True, self.OpticalSystem.observingModes)[0], self.cachefname)
+        self.valfZmax, self.absTimefZmax = self.ZodiacalLight.calcfZmax(np.arange(self.TargetList.nStars), self.Observatory, self.TargetList, self.TimeKeeping, list(filter(lambda mode: mode['detectionMode'] == True, self.OpticalSystem.observingModes))[0], self.cachefname)
 
 
         assert isinstance(staticOptTimes, bool), 'staticOptTimes must be boolean.'
@@ -47,7 +47,7 @@ class SLSQPSchedulerE(SurveySimulation):
 
 
         #some global defs
-        self.detmode = filter(lambda mode: mode['detectionMode'] == True, self.OpticalSystem.observingModes)[0]
+        self.detmode = list(filter(lambda mode: mode['detectionMode'] == True, self.OpticalSystem.observingModes))[0]
         self.ohTimeTot = self.Observatory.settlingTime + self.detmode['syst']['ohTime']
         self.maxTime = self.TimeKeeping.missionLife*self.TimeKeeping.missionPortion
 

--- a/EXOSIMS/SurveySimulation/SLSQPSchedulerF.py
+++ b/EXOSIMS/SurveySimulation/SLSQPSchedulerF.py
@@ -35,7 +35,7 @@ class SLSQPSchedulerF(SurveySimulation):
         SurveySimulation.__init__(self, **specs)
 
         #Calculate fZmax
-        self.valfZmax, self.absTimefZmax = self.ZodiacalLight.calcfZmax(np.arange(self.TargetList.nStars), self.Observatory, self.TargetList, self.TimeKeeping, filter(lambda mode: mode['detectionMode'] == True, self.OpticalSystem.observingModes)[0], self.cachefname)
+        self.valfZmax, self.absTimefZmax = self.ZodiacalLight.calcfZmax(np.arange(self.TargetList.nStars), self.Observatory, self.TargetList, self.TimeKeeping, list(filter(lambda mode: mode['detectionMode'] == True, self.OpticalSystem.observingModes))[0], self.cachefname)
 
         assert isinstance(staticOptTimes, bool), 'staticOptTimes must be boolean.'
         self.staticOptTimes = staticOptTimes
@@ -46,7 +46,7 @@ class SLSQPSchedulerF(SurveySimulation):
 
 
         #some global defs
-        self.detmode = filter(lambda mode: mode['detectionMode'] == True, self.OpticalSystem.observingModes)[0]
+        self.detmode = list(filter(lambda mode: mode['detectionMode'] == True, self.OpticalSystem.observingModes))[0]
         self.ohTimeTot = self.Observatory.settlingTime + self.detmode['syst']['ohTime']
         self.maxTime = self.TimeKeeping.missionLife*self.TimeKeeping.missionPortion
 

--- a/EXOSIMS/SurveySimulation/SLSQPSchedulerG.py
+++ b/EXOSIMS/SurveySimulation/SLSQPSchedulerG.py
@@ -43,7 +43,7 @@ class SLSQPSchedulerG(SurveySimulation):
 
 
         #some global defs
-        self.detmode = filter(lambda mode: mode['detectionMode'] == True, self.OpticalSystem.observingModes)[0]
+        self.detmode = list(filter(lambda mode: mode['detectionMode'] == True, self.OpticalSystem.observingModes))[0]
         self.ohTimeTot = self.Observatory.settlingTime + self.detmode['syst']['ohTime']
         self.maxTime = self.TimeKeeping.missionLife*self.TimeKeeping.missionPortion
 

--- a/EXOSIMS/SurveySimulation/SLSQPSchedulerH.py
+++ b/EXOSIMS/SurveySimulation/SLSQPSchedulerH.py
@@ -35,7 +35,7 @@ class SLSQPSchedulerH(SurveySimulation):
         SurveySimulation.__init__(self, **specs)
 
         #Calculate fZmax
-        self.valfZmax, self.absTimefZmax = self.ZodiacalLight.calcfZmax(np.arange(self.TargetList.nStars), self.Observatory, self.TargetList, self.TimeKeeping, filter(lambda mode: mode['detectionMode'] == True, self.OpticalSystem.observingModes)[0], self.cachefname)
+        self.valfZmax, self.absTimefZmax = self.ZodiacalLight.calcfZmax(np.arange(self.TargetList.nStars), self.Observatory, self.TargetList, self.TimeKeeping, list(filter(lambda mode: mode['detectionMode'] == True, self.OpticalSystem.observingModes))[0], self.cachefname)
 
         assert isinstance(staticOptTimes, bool), 'staticOptTimes must be boolean.'
         self.staticOptTimes = staticOptTimes
@@ -46,7 +46,7 @@ class SLSQPSchedulerH(SurveySimulation):
 
 
         #some global defs
-        self.detmode = filter(lambda mode: mode['detectionMode'] == True, self.OpticalSystem.observingModes)[0]
+        self.detmode = list(filter(lambda mode: mode['detectionMode'] == True, self.OpticalSystem.observingModes))[0]
         self.ohTimeTot = self.Observatory.settlingTime + self.detmode['syst']['ohTime']
         self.maxTime = self.TimeKeeping.missionLife*self.TimeKeeping.missionPortion
 

--- a/EXOSIMS/SurveySimulation/SLSQPSchedulerI.py
+++ b/EXOSIMS/SurveySimulation/SLSQPSchedulerI.py
@@ -43,7 +43,7 @@ class SLSQPSchedulerI(SurveySimulation):
 
 
         #some global defs
-        self.detmode = filter(lambda mode: mode['detectionMode'] == True, self.OpticalSystem.observingModes)[0]
+        self.detmode = list(filter(lambda mode: mode['detectionMode'] == True, self.OpticalSystem.observingModes))[0]
         self.ohTimeTot = self.Observatory.settlingTime + self.detmode['syst']['ohTime']
         self.maxTime = self.TimeKeeping.missionLife*self.TimeKeeping.missionPortion
 

--- a/EXOSIMS/SurveySimulation/SS_char_only.py
+++ b/EXOSIMS/SurveySimulation/SS_char_only.py
@@ -56,7 +56,7 @@ class SS_char_only(SurveySimulation):
         # begin Survey, and loop until mission is finished
         log_begin = 'OB%s: survey beginning.'%(TK.OBnumber + 1)
         self.logger.info(log_begin)
-        print log_begin
+        print(log_begin)
         t0 = time.time()
         sInd = None
         cnt = 0
@@ -89,7 +89,7 @@ class SS_char_only(SurveySimulation):
                         + 'mission time: %s')%(cnt, sInd+1, TL.nStars, len(pInds), 
                         TK.obsStart.round(2))
                 self.logger.info(log_obs)
-                print log_obs
+                print(log_obs)
 
                 # PERFORM DETECTION and populate revisit list attribute.
                 # # First store fEZ, dMag, WA
@@ -156,7 +156,7 @@ class SS_char_only(SurveySimulation):
                 
                 # with occulter, if spacecraft fuel is depleted, exit loop
                 if OS.haveOcculter and Obs.scMass < Obs.dryMass:
-                    print 'Total fuel mass exceeded at %s'%TK.obsEnd.round(2)
+                    print('Total fuel mass exceeded at %s'%TK.obsEnd.round(2))
                     break
         
         else:
@@ -165,7 +165,7 @@ class SS_char_only(SurveySimulation):
                     + "Simulation duration: %s.\n"%dtsim.astype('int') \
                     + "Results stored in SurveySimulation.DRM (Design Reference Mission)."
             self.logger.info(log_end)
-            print log_end
+            print(log_end)
 
 
     def choose_next_target(self, old_sInd, sInds, slewTimes, t_dets):
@@ -366,7 +366,7 @@ class SS_char_only(SurveySimulation):
             log_char = '   - Charact. planet(s) %s (%s/%s detected)'%(pIndsChar, 
                     len(pIndsChar), len(pIndsDet))
             self.logger.info(log_char)
-            print log_char
+            print(log_char)
             
             # SNR CALCULATION:
             # first, calculate SNR for observable planets (without false alarm)

--- a/EXOSIMS/SurveySimulation/SS_char_only.py
+++ b/EXOSIMS/SurveySimulation/SS_char_only.py
@@ -44,9 +44,9 @@ class SS_char_only(SurveySimulation):
         
         # choose observing modes selected for detection (default marked with a flag)
         allModes = OS.observingModes
-        det_mode = filter(lambda mode: mode['detectionMode'] == True, allModes)[0]
+        det_mode = list(filter(lambda mode: mode['detectionMode'] == True, allModes))[0]
         # and for characterization (default is first spectro/IFS mode)
-        spectroModes = filter(lambda mode: 'spec' in mode['inst']['name'], allModes)
+        spectroModes = list(filter(lambda mode: 'spec' in mode['inst']['name'], allModes))
         if np.any(spectroModes):
             char_mode = spectroModes[0]
         # if no spectro mode, default char mode is first observing mode

--- a/EXOSIMS/SurveySimulation/SS_char_only2.py
+++ b/EXOSIMS/SurveySimulation/SS_char_only2.py
@@ -46,9 +46,9 @@ class SS_char_only2(SurveySimulation):
         
         # choose observing modes selected for detection (default marked with a flag)
         allModes = OS.observingModes
-        det_mode = filter(lambda mode: mode['detectionMode'] == True, allModes)[0]
+        det_mode = list(filter(lambda mode: mode['detectionMode'] == True, allModes))[0]
         # and for characterization (default is first spectro/IFS mode)
-        spectroModes = filter(lambda mode: 'spec' in mode['inst']['name'], allModes)
+        spectroModes = list(filter(lambda mode: 'spec' in mode['inst']['name'], allModes))
         if np.any(spectroModes):
             char_mode = spectroModes[0]
         # if no spectro mode, default char mode is first observing mode

--- a/EXOSIMS/SurveySimulation/SS_char_only2.py
+++ b/EXOSIMS/SurveySimulation/SS_char_only2.py
@@ -58,7 +58,7 @@ class SS_char_only2(SurveySimulation):
         # begin Survey, and loop until mission is finished
         log_begin = 'OB%s: survey beginning.'%(TK.OBnumber + 1)
         self.logger.info(log_begin)
-        print log_begin
+        print(log_begin)
         t0 = time.time()
         sInd = None
         cnt = 0
@@ -91,7 +91,7 @@ class SS_char_only2(SurveySimulation):
                         + 'mission time: %s')%(cnt, sInd+1, TL.nStars, len(pInds), 
                         TK.obsStart.round(2))
                 self.logger.info(log_obs)
-                print log_obs
+                print(log_obs)
 
                 FA = False
                 
@@ -143,7 +143,7 @@ class SS_char_only2(SurveySimulation):
                 
                 # with occulter, if spacecraft fuel is depleted, exit loop
                 if OS.haveOcculter and Obs.scMass < Obs.dryMass:
-                    print 'Total fuel mass exceeded at %s'%TK.obsEnd.round(2)
+                    print('Total fuel mass exceeded at %s'%TK.obsEnd.round(2))
                     break
         
         else:
@@ -152,7 +152,7 @@ class SS_char_only2(SurveySimulation):
                     + "Simulation duration: %s.\n"%dtsim.astype('int') \
                     + "Results stored in SurveySimulation.DRM (Design Reference Mission)."
             self.logger.info(log_end)
-            print log_end
+            print(log_end)
 
 
     def choose_next_target(self, old_sInd, sInds, slewTimes, intTimes):
@@ -307,7 +307,7 @@ class SS_char_only2(SurveySimulation):
             log_char = '   - Charact. planet(s) %s (%s/%s detected)'%(pIndsChar, 
                     len(pIndsChar), len(pIndsDet))
             self.logger.info(log_char)
-            print log_char
+            print(log_char)
             
             # SNR CALCULATION:
             # first, calculate SNR for observable planets (without false alarm)

--- a/EXOSIMS/SurveySimulation/SS_det_only.py
+++ b/EXOSIMS/SurveySimulation/SS_det_only.py
@@ -32,9 +32,9 @@ class SS_det_only(SurveySimulation):
         
         # choose observing modes selected for detection (default marked with a flag)
         allModes = OS.observingModes
-        det_mode = filter(lambda mode: mode['detectionMode'] == True, allModes)[0]
+        det_mode = list(filter(lambda mode: mode['detectionMode'] == True, allModes))[0]
         # and for characterization (default is first spectro/IFS mode)
-        spectroModes = filter(lambda mode: 'spec' in mode['inst']['name'], allModes)
+        spectroModes = list(filter(lambda mode: 'spec' in mode['inst']['name'], allModes))
         if np.any(spectroModes):
             char_mode = spectroModes[0]
         # if no spectro mode, default char mode is first observing mode

--- a/EXOSIMS/SurveySimulation/SS_det_only.py
+++ b/EXOSIMS/SurveySimulation/SS_det_only.py
@@ -39,7 +39,7 @@ class SS_det_only(SurveySimulation):
         # begin Survey, and loop until mission is finished
         log_begin = 'OB%s: survey beginning.'%(TK.OBnumber + 1)
         self.logger.info(log_begin)
-        print log_begin
+        print(log_begin)
         t0 = time.time()
         sInd = None
         cnt = 0
@@ -72,7 +72,7 @@ class SS_det_only(SurveySimulation):
                         + 'mission time: %s')%(cnt, sInd+1, TL.nStars, len(pInds), 
                         TK.obsStart.round(2))
                 self.logger.info(log_obs)
-                print log_obs
+                print(log_obs)
                 
                 # PERFORM DETECTION and populate revisit list attribute
                 detected, det_fZ, det_systemParams, det_SNR, FA = \
@@ -118,7 +118,7 @@ class SS_det_only(SurveySimulation):
                 
                 # with occulter, if spacecraft fuel is depleted, exit loop
                 if OS.haveOcculter and Obs.scMass < Obs.dryMass:
-                    print 'Total fuel mass exceeded at %s'%TK.obsEnd.round(2)
+                    print('Total fuel mass exceeded at %s'%TK.obsEnd.round(2))
                     break
         
         else:
@@ -127,7 +127,7 @@ class SS_det_only(SurveySimulation):
                     + "Simulation duration: %s.\n"%dtsim.astype('int') \
                     + "Results stored in SurveySimulation.DRM (Design Reference Mission)."
             self.logger.info(log_end)
-            print log_end
+            print(log_end)
 
     def next_target(self, old_sInd, mode):
         """Finds index of next target star and calculates its integration time.
@@ -445,8 +445,8 @@ class SS_det_only(SurveySimulation):
             H = pickle.load(open(Cpath, 'rb'))
         else:
             # run Monte Carlo simulation and pickle the resulting array
-            print 'Cached completeness file not found at "%s".' % Cpath
-            print 'Beginning Monte Carlo completeness calculations.'
+            print('Cached completeness file not found at "%s".' % Cpath)
+            print('Beginning Monte Carlo completeness calculations.')
             
             t0, t1 = None, None # keep track of per-iteration time
             for i in xrange(steps):
@@ -455,7 +455,7 @@ class SS_det_only(SurveySimulation):
                     delta_t_msg = '' # no message
                 else:
                     delta_t_msg = '[%.3f s/iteration]' % (t1 - t0)
-                print 'Completeness iteration: %5d / %5d %s' % (i+1, steps, delta_t_msg)
+                print('Completeness iteration: %5d / %5d %s' % (i+1, steps, delta_t_msg))
                 # get completeness histogram
                 h, xedges, yedges = self.hist(nplan, xedges, yedges)
                 if i == 0:
@@ -469,8 +469,8 @@ class SS_det_only(SurveySimulation):
                         
             # store 2D completeness pdf array as .comp file
             pickle.dump(H, open(Cpath, 'wb'))
-            print 'Monte Carlo completeness calculations finished'
-            print '2D completeness array stored in %r' % Cpath
+            print('Monte Carlo completeness calculations finished')
+            print('2D completeness array stored in %r' % Cpath)
         
         return H, xedges, yedges
 

--- a/EXOSIMS/SurveySimulation/SS_det_only.py
+++ b/EXOSIMS/SurveySimulation/SS_det_only.py
@@ -3,6 +3,11 @@ import os
 import astropy.units as u
 import numpy as np
 import time
+import sys
+
+# Python 3 compatibility:
+if sys.version_info[0] > 2:
+    xrange = range
 
 class SS_det_only(SurveySimulation):
     """

--- a/EXOSIMS/SurveySimulation/linearJScheduler_3DDPC.py
+++ b/EXOSIMS/SurveySimulation/linearJScheduler_3DDPC.py
@@ -46,9 +46,9 @@ class linearJScheduler_3DDPC(linearJScheduler_DDPC):
         
         # choose observing modes selected for detection (default marked with a flag)
         allModes = OS.observingModes
-        det_modes = filter(lambda mode: 'imag' in mode['inst']['name'], allModes)[1:]
+        det_modes = list(filter(lambda mode: 'imag' in mode['inst']['name'], allModes))[1:]
         # and for characterization (default is first spectro/IFS mode)
-        spectroModes = filter(lambda mode: 'spec' in mode['inst']['name'], allModes)
+        spectroModes = list(filter(lambda mode: 'spec' in mode['inst']['name'], allModes))
         if np.any(spectroModes):
             char_modes = spectroModes
         # if no spectro mode, default char mode is first observing mode

--- a/EXOSIMS/SurveySimulation/linearJScheduler_DDPC.py
+++ b/EXOSIMS/SurveySimulation/linearJScheduler_DDPC.py
@@ -32,7 +32,7 @@ class linearJScheduler_DDPC(linearJScheduler):
         TL = self.TargetList
 
         allModes = OS.observingModes
-        num_char_modes = len(filter(lambda mode: 'spec' in mode['inst']['name'], allModes))
+        num_char_modes = len(list(filter(lambda mode: 'spec' in mode['inst']['name'], allModes)))
         self.fullSpectra = np.zeros((num_char_modes, SU.nPlans), dtype=int)
         self.partialSpectra = np.zeros((num_char_modes, SU.nPlans), dtype=int)
 
@@ -57,9 +57,9 @@ class linearJScheduler_DDPC(linearJScheduler):
         
         # choose observing modes selected for detection (default marked with a flag)
         allModes = OS.observingModes
-        det_modes = filter(lambda mode: 'imag' in mode['inst']['name'], allModes)
+        det_modes = list(filter(lambda mode: 'imag' in mode['inst']['name'], allModes))
         # and for characterization (default is first spectro/IFS mode)
-        spectroModes = filter(lambda mode: 'spec' in mode['inst']['name'], allModes)
+        spectroModes = list(filter(lambda mode: 'spec' in mode['inst']['name'], allModes))
         if np.any(spectroModes):
             char_modes = spectroModes
         # if no spectro mode, default char mode is first observing mode

--- a/EXOSIMS/SurveySimulation/linearJScheduler_det_only.py
+++ b/EXOSIMS/SurveySimulation/linearJScheduler_det_only.py
@@ -71,9 +71,9 @@ class linearJScheduler_det_only(SurveySimulation):
         
         # choose observing modes selected for detection (default marked with a flag)
         allModes = OS.observingModes
-        det_mode = filter(lambda mode: mode['detectionMode'] == True, allModes)[0]
+        det_mode = list(filter(lambda mode: mode['detectionMode'] == True, allModes))[0]
         # and for characterization (default is first spectro/IFS mode)
-        spectroModes = filter(lambda mode: 'spec' in mode['inst']['name'], allModes)
+        spectroModes = list(filter(lambda mode: 'spec' in mode['inst']['name'], allModes))
         if np.any(spectroModes):
             char_mode = spectroModes[0]
         # if no spectro mode, default char mode is first observing mode

--- a/EXOSIMS/SurveySimulation/starkAYO_staticSchedule.py
+++ b/EXOSIMS/SurveySimulation/starkAYO_staticSchedule.py
@@ -7,6 +7,11 @@ try:
     import cPickle as pickle
 except:
     import pickle
+import sys
+
+# Python 3 compatibility:
+if sys.version_info[0] > 2:
+    xrange = range
 
 class starkAYO_staticSchedule(SurveySimulation):
     """starkAYO _static Scheduler

--- a/EXOSIMS/SurveySimulation/tieredScheduler.py
+++ b/EXOSIMS/SurveySimulation/tieredScheduler.py
@@ -856,7 +856,7 @@ class tieredScheduler(SurveySimulation):
             self.curves = curves
 
         # if no curves for current mode
-        if mode['systName'] not in self.curves.keys() or TL.nStars != self.curves[mode['systName']].shape[1]:
+        if mode['systName'] not in self.curves or TL.nStars != self.curves[mode['systName']].shape[1]:
             for t_i, t in enumerate(intTimes):
                 fZ = ZL.fZ(Obs, TL, sInds, startTime, mode)
                 curve[0,:,t_i] = Comp.comp_per_intTime(t, TL, sInds, fZ, fEZ, WA, mode)
@@ -950,7 +950,7 @@ class tieredScheduler(SurveySimulation):
         SNR = np.zeros(len(det))
         intTime = None
         if len(det) == 0: # nothing to characterize
-            if sInd not in self.sInd_charcounts.keys():
+            if sInd not in self.sInd_charcounts:
                 self.sInd_charcounts[sInd] = characterized
             return characterized, fZ, systemParams, SNR, intTime
 
@@ -1104,7 +1104,7 @@ class tieredScheduler(SurveySimulation):
             characterized[char] = -1
             all_full = np.copy(characterized)
             all_full[char] = 0
-            if sInd not in self.sInd_charcounts.keys():
+            if sInd not in self.sInd_charcounts:
                 self.sInd_charcounts[sInd] = all_full
             else:
                 self.sInd_charcounts[sInd] = self.sInd_charcounts[sInd] + all_full

--- a/EXOSIMS/SurveySimulation/tieredScheduler.py
+++ b/EXOSIMS/SurveySimulation/tieredScheduler.py
@@ -133,9 +133,9 @@ class tieredScheduler(SurveySimulation):
         self.currentSep = Obs.occulterSep
         
         # Choose observing modes selected for detection (default marked with a flag),
-        det_mode = filter(lambda mode: mode['detectionMode'] == True, OS.observingModes)[0]
+        det_mode = list(filter(lambda mode: mode['detectionMode'] == True, OS.observingModes))[0]
         # and for characterization (default is first spectro/IFS mode)
-        spectroModes = filter(lambda mode: 'spec' in mode['inst']['name'], OS.observingModes)
+        spectroModes = list(filter(lambda mode: 'spec' in mode['inst']['name'], OS.observingModes))
         if np.any(spectroModes):
             char_mode = spectroModes[0]
         # if no spectro mode, default char mode is first observing mode

--- a/EXOSIMS/SurveySimulation/tieredScheduler_DD.py
+++ b/EXOSIMS/SurveySimulation/tieredScheduler_DD.py
@@ -46,9 +46,9 @@ class tieredScheduler_DD(tieredScheduler):
         self.currentSep = Obs.occulterSep
         
         # Choose observing modes selected for detection (default marked with a flag),
-        det_modes = filter(lambda mode: 'imag' in mode['inst']['name'], OS.observingModes)
+        det_modes = list(filter(lambda mode: 'imag' in mode['inst']['name'], OS.observingModes))
         # and for characterization (default is first spectro/IFS mode)
-        spectroModes = filter(lambda mode: 'spec' in mode['inst']['name'], OS.observingModes)
+        spectroModes = list(filter(lambda mode: 'spec' in mode['inst']['name'], OS.observingModes))
         if np.any(spectroModes):
             char_mode = spectroModes[0]
         # if no spectro mode, default char mode is first observing mode

--- a/EXOSIMS/TargetList/KnownRVPlanetsTargetList.py
+++ b/EXOSIMS/TargetList/KnownRVPlanetsTargetList.py
@@ -68,7 +68,7 @@ class KnownRVPlanetsTargetList(TargetList):
             if type(ma.fill_value) == np.float64:
                 setattr(self, att, ma.filled(np.nanmedian(ma)))
             else:
-                if att == 'Name':
+                if (att == 'Name') or (att == 'Spec'):
                     setattr(self, att, ma.data.astype(str))
                 else:
                     setattr(self, att, ma.data)

--- a/EXOSIMS/TargetList/KnownRVPlanetsTargetList.py
+++ b/EXOSIMS/TargetList/KnownRVPlanetsTargetList.py
@@ -68,7 +68,10 @@ class KnownRVPlanetsTargetList(TargetList):
             if type(ma.fill_value) == np.float64:
                 setattr(self, att, ma.filled(np.nanmedian(ma)))
             else:
-                setattr(self, att, ma.data)
+                if att == 'Name':
+                    setattr(self, att, ma.data.astype(str))
+                else:
+                    setattr(self, att, ma.data)
         # astropy units
         self.parx = self.parx*u.mas
         self.dist = self.dist*u.pc

--- a/EXOSIMS/TargetList/KnownRVPlanetsTargetList.py
+++ b/EXOSIMS/TargetList/KnownRVPlanetsTargetList.py
@@ -63,7 +63,7 @@ class KnownRVPlanetsTargetList(TargetList):
         self.nStars = len(tmp)
         assert self.nStars, "Target list is empty: nStars = %r"%self.nStars
         
-        for att in self.atts_mapping.keys():
+        for att in self.atts_mapping:
             ma = tmp[self.atts_mapping[att]]
             if type(ma.fill_value) == np.float64:
                 setattr(self, att, ma.filled(np.nanmedian(ma)))

--- a/EXOSIMS/ZodiacalLight/Stark.py
+++ b/EXOSIMS/ZodiacalLight/Stark.py
@@ -80,12 +80,12 @@ class Stark(ZodiacalLight):
                 105, 120, 135, 150, 165, 180]) # deg
         lat_pts = np.array([0., 5, 10, 15, 20, 25, 30, 45, 60, 75, 90]) # deg
         y_pts, x_pts = np.meshgrid(lat_pts, lon_pts)
-        points = np.array(zip(np.concatenate(x_pts), np.concatenate(y_pts)))
+        points = np.array(list(zip(np.concatenate(x_pts), np.concatenate(y_pts))))
         # create data values, normalized by (90,0) value
         z = Izod/Izod[12,0]
         values = z.reshape(z.size)
         # interpolates 2D
-        fbeta = griddata(points, values, zip(lon, lat))
+        fbeta = griddata(points, values, np.array(list(zip(lon, lat))))
         
         # wavelength dependence, from Table 19 in Leinert et al 1998
         # interpolated w/ a quadratic in log-log space

--- a/EXOSIMS/ZodiacalLight/Stark.py
+++ b/EXOSIMS/ZodiacalLight/Stark.py
@@ -12,6 +12,11 @@ except:
     import pickle
 from numpy import nan
 from astropy.time import Time
+import sys
+
+# Python 3 compatibility:
+if sys.version_info[0] > 2:
+    xrange = range
 
 class Stark(ZodiacalLight):
     """Stark Zodiacal Light class

--- a/EXOSIMS/e2eTests.py
+++ b/EXOSIMS/e2eTests.py
@@ -33,17 +33,17 @@ def run_e2e_tests():
     testdir = os.path.join(basedir, 'Scripts', 'TestScripts')
     
     if not os.path.isdir(testdir):
-        print "Cannot find test script directory in " \
-                + "EXOSIMS_ROOT/EXOSIMS/Scripts/TestScripts"
+        print("Cannot find test script directory in " \
+                + "EXOSIMS_ROOT/EXOSIMS/Scripts/TestScripts")
         return
     
     scripts = glob.glob(os.path.join(testdir, "*.json"))
     
     if not scripts:
-        print "No test scripts found in %s"%testdir
+        print("No test scripts found in %s"%testdir)
         return
     
-    print "%d test scripts found"%len(scripts)
+    print("%d test scripts found"%len(scripts))
     
     scripts = np.sort(scripts)
     
@@ -51,59 +51,59 @@ def run_e2e_tests():
     n = 0
     
     for j,script in enumerate(scripts):
-        print "Running script: %s (%d/%d)"%(os.path.basename(script), j+1, len(scripts))
+        print("Running script: %s (%d/%d)"%(os.path.basename(script), j+1, len(scripts)))
         if len(os.path.basename(script)) > n:
             n = len(os.path.basename(script)) 
         
         try:
             sim = EXOSIMS.MissionSim.MissionSim(script)
         except:
-            print "Instantiation failed."
-            print sys.exc_info()[0]
-            print "\n\n\n"
+            print("Instantiation failed.")
+            print(sys.exc_info()[0])
+            print("\n\n\n")
             results.append("FAIL - Instantiation")
             continue
         
         try:
             res = sim.run_sim()
         except:
-            print "Run failed."
-            print sys.exc_info()[0]
-            print "\n\n\n"
+            print("Run failed.")
+            print(sys.exc_info()[0])
+            print("\n\n\n")
             results.append("FAIL - Execution")
             continue
 
         try:
             sim.reset_sim()
         except:
-            print "Reset failed."
-            print sys.exc_info()[0]
-            print "\n\n\n"
+            print("Reset failed.")
+            print(sys.exc_info()[0])
+            print("\n\n\n")
             results.append("FAIL - Reset")
             continue
 
         try:
             sim.run_sim()
         except:
-            print "Second run failed."
-            print sys.exc_info()[0]
-            print "\n\n\n"
+            print("Second run failed.")
+            print(sys.exc_info()[0])
+            print("\n\n\n")
             results.append("FAIL - Execution after Reset")
             continue
 
         del sim
         
         results.append("PASS")
-        print "\n\n\n"
+        print("\n\n\n")
     
     #results
-    print "Summary"
-    print "-"*80
+    print("Summary")
+    print("-"*80)
     for script,result in zip(scripts, results):
         tmp = '{0:' + str(n + 5) + '} ==> {1}'
-        print tmp.format(os.path.basename(script), result)
+        print(tmp.format(os.path.basename(script), result))
     
-    print "-"*80
+    print("-"*80)
 
 
 if __name__ == '__main__':

--- a/EXOSIMS/run/runQueue.py
+++ b/EXOSIMS/run/runQueue.py
@@ -144,7 +144,7 @@ if __name__ == "__main__":
     ####Check if Any of the Scripts have already been run... and remove from scriptNames list ##########
     try:#check through log file if it exists
         with open(runLogPath + "runLog.csv","w+") as myfile:
-            scriptsRun = map(lambda s: s.strip(), myfile.readlines())
+            scriptsRun = list(map(lambda s: s.strip(), myfile.readlines()))
             for scriptRun in scriptsRun:
                 if scriptRun in queueData['scriptNames']:
                     tmpIndex = queueData['scriptNames'].index(scriptRun)

--- a/EXOSIMS/run/runQueue.py
+++ b/EXOSIMS/run/runQueue.py
@@ -83,7 +83,7 @@ def parse_qFPath(args):
 def parse_ScriptsPath(args, queueData):
     if args.ScriptsPath is None:
         ScriptsPath = '../../../Scripts/'#Default. Explicitly when run from run folder
-        if queueData.has_key('ScriptsPath'):
+        if 'ScriptsPath' in queueData:
             ScriptsPath = queueData['ScriptsPath'] #extract from queue Folder
     else:
         ScriptsPath = args.ScriptsPath[0]
@@ -92,7 +92,7 @@ def parse_ScriptsPath(args, queueData):
 def parse_runLogPath(args,queueData):
     if args.runLogPath is None:
         runLogPath = '../../../cache/'#Default
-        if queueData.has_key('runLogPath'):
+        if 'runLogPath' in queueData:
             runLogPath = queueData['runLogPath'] #extract from queue Folder
     else:
         runLogPath = args.runLogPath[0]
@@ -117,7 +117,7 @@ def scriptNamesInScriptPath(queueData, ScriptsPath):
 def outpathCore(args,queueData):
     if args.outpath is None:
         outpathCore = '../../../cache/'#Default
-        if queueData.has_key('outpath'):
+        if 'outpath' in queueData:
             outpathCore = queueData['outpath'] #extract from queue Folder
     else:
         outpathCore = args.outpath[0]

--- a/EXOSIMS/run/runQueue.py
+++ b/EXOSIMS/run/runQueue.py
@@ -23,7 +23,10 @@ import EXOSIMS.MissionSim
 import os
 import os.path
 import sys
-import cPickle
+try:
+    import cPickle as pickle
+except ImportError:
+    import pickle
 import time
 import random
 import argparse
@@ -64,7 +67,7 @@ def run_one(genNewPlanets=True, rewindPlanets=True, outpath='.'):
     pklname = 'run'+str(int(time.clock()*100))+''.join(["%s" % random.randint(0, 9) for num in range(5)]) + '.pkl'
     pklpath = os.path.join(outpath, pklname)
     with open(pklpath, 'wb') as f:
-        cPickle.dump({'DRM':DRM,'systems':systems,'seed':seed}, f)
+        pickle.dump({'DRM':DRM,'systems':systems,'seed':seed}, f)
         
     return 0
 

--- a/EXOSIMS/run/run_ipcluster_ensemble.py
+++ b/EXOSIMS/run/run_ipcluster_ensemble.py
@@ -106,7 +106,7 @@ if __name__ == "__main__":
         outpath = args.outpath[0]
 
     if not os.path.exists(outpath):
-        print "Creating output path %s"%outpath
+        print("Creating output path %s"%outpath)
         os.makedirs(outpath)
 
     sim = EXOSIMS.MissionSim.MissionSim(scriptfile)
@@ -114,7 +114,7 @@ if __name__ == "__main__":
 
     subtime = time.ctime()
     kwargs = {'outpath':outpath}
-    print "Submitting run on: %s"%subtime
+    print("Submitting run on: %s"%subtime)
     res = sim.run_ensemble(int(args.numruns[0]),run_one=run_one,kwargs=kwargs)
 
     if args.email is not None:

--- a/EXOSIMS/run/run_ipcluster_ensemble.py
+++ b/EXOSIMS/run/run_ipcluster_ensemble.py
@@ -28,7 +28,10 @@ import EXOSIMS
 import EXOSIMS.MissionSim
 import os
 import os.path
-import cPickle
+try:
+    import cPickle as pickle
+except ImportError:
+    import pickle
 import time
 import random
 import argparse
@@ -67,7 +70,7 @@ def run_one(genNewPlanets=True, rewindPlanets=True, outpath='.'):
     pklname = 'run'+str(int(time.clock()*100))+''.join(["%s" % random.randint(0, 9) for num in range(5)]) + '.pkl'
     pklpath = os.path.join(outpath, pklname)
     with open(pklpath, 'wb') as f:
-        cPickle.dump({'DRM':DRM,'systems':systems,'seed':seed}, f)
+        pickle.dump({'DRM':DRM,'systems':systems,'seed':seed}, f)
         
     return 0
 

--- a/EXOSIMS/util/CheckScript.py
+++ b/EXOSIMS/util/CheckScript.py
@@ -61,9 +61,9 @@ class CheckScript(object):
                 The concatinated output text
         """
 
-        unused = np.setdiff1d(json1.keys(), json2.keys())
-        unspecified = np.setdiff1d(json2.keys(), json1.keys())
-        both_use = np.intersect1d(json1.keys(), json2.keys())
+        unused = np.setdiff1d(list(json1), list(json2))
+        unspecified = np.setdiff1d(list(json2), list(json1))
+        both_use = np.intersect1d(list(json1), list(json2))
         text_buffer = "  " * recurse_level
 
         # Check for unused fields
@@ -89,7 +89,7 @@ class CheckScript(object):
                 if pretty_print:
                     vprint(out)
                 outtext += out + '\n'
-                for mkey in json2[jkey].keys():
+                for mkey in json2[jkey]:
                     if json1[jkey][mkey] != json2[jkey][mkey] and json1[jkey][mkey] != " " and json1[jkey][mkey] != "":
                         out = "  WARNING 3: module {} from script file does not match module {} "\
                               "from simulation".format([json1[jkey][mkey]], [json2[jkey][mkey]])
@@ -102,7 +102,7 @@ class CheckScript(object):
                             vprint(out)
                         outtext += out + '\n'
             elif type(json1[jkey]) == type({}) and type(json2[jkey]) == type({}):
-                if "name" in json1[jkey].keys():
+                if "name" in json1[jkey]:
                     out = "NOTE: Moving down a level from key: {} to ".format(jkey, json1[jkey]["name"])
                 else:
                     out = "NOTE: Moving down a level from key: {}".format(jkey)
@@ -115,7 +115,7 @@ class CheckScript(object):
                     for i in range(len(items)):
                         if json1[jkey][i] != json2[jkey][i]:
                             if type(json1[jkey][i]) == type({}) and type(json2[jkey][i]) == type({}):
-                                if "name" in json1[jkey][i].keys():
+                                if "name" in json1[jkey][i]:
                                     out = "NOTE: Moving down a level from key: {} to {}".format(jkey, json1[jkey][i]["name"])
                                 else:
                                     out = "NOTE: Moving down a level from key: {}".format(jkey)

--- a/EXOSIMS/util/RejectionSampler.py
+++ b/EXOSIMS/util/RejectionSampler.py
@@ -79,7 +79,7 @@ class RejectionSampler():
             raise Exception("Failed to converge.")
         
         if verb:
-            print 'Finished in '+repr(numIter)+' iterations.'
+            print('Finished in '+repr(numIter)+' iterations.')
         
         return X
 

--- a/EXOSIMS/util/analysis_tools.py
+++ b/EXOSIMS/util/analysis_tools.py
@@ -26,7 +26,7 @@ def genOutSpec_ensemble(scriptfile, savefolder, nb_run_sim=1, **specs):
     """
     
     for j in xrange(int(nb_run_sim)):
-        print '\nSurvey simulation number %s/%s' %(j+1, int(nb_run_sim))
+        print('\nSurvey simulation number %s/%s' %(j+1, int(nb_run_sim)))
         reload(EXOSIMS)
         reload(EXOSIMS.MissionSim)
         sim = EXOSIMS.MissionSim.MissionSim(scriptfile, **specs)

--- a/EXOSIMS/util/analysis_tools.py
+++ b/EXOSIMS/util/analysis_tools.py
@@ -3,6 +3,11 @@ import os.path,json
 from scipy.stats import norm
 from matplotlib.pyplot import *
 import pickle
+import sys
+
+# Python 3 compatibility:
+if sys.version_info[0] > 2:
+    xrange = range
 
 def save_obj(obj, name):
     with open(name + '.pkl', 'wb') as f:

--- a/EXOSIMS/util/collateAllUniqueDetections.py
+++ b/EXOSIMS/util/collateAllUniqueDetections.py
@@ -150,8 +150,6 @@ class collateAllUniqueDetections(object):
                 pass
             lines3 = [','.join(line) for line in lines2 if float(line[1]) < 24764.0/6371.0]
             outtext.append('\n'.join(lines3))#OUTTEXT contains a complete list of all sub-neptune detections
-            #outtext = ','.join(map(str, lines)) 
-            #','.join([str(bit) for bit in [1,2,'taco']])
         with open(os.path.join(PPoutpath,'NEIDallSubNeptunes.txt'), 'w') as g: #Write to file
             g.write('\n'.join(outtext))
         

--- a/EXOSIMS/util/collateAllUniqueDetections.py
+++ b/EXOSIMS/util/collateAllUniqueDetections.py
@@ -176,7 +176,7 @@ class collateAllUniqueDetections(object):
         starNamesDat = {}
         for line in lines:
             planet = line.split(',')[0]
-            if planet in starNamesDat.keys():
+            if planet in starNamesDat:
                 starNamesDat[planet] += 1
             else:
                 starNamesDat[planet] = 1
@@ -186,7 +186,7 @@ class collateAllUniqueDetections(object):
             json.dump(starNamesDat, g)#g.write('\n'.join(outtext))
 
 
-        starKeys = starNamesDat.keys()
+        starKeys = list(starNamesDat)
         tmpstarNames = list()
         occurence = list()
         for key in starKeys:
@@ -202,8 +202,6 @@ class collateAllUniqueDetections(object):
         with open(os.path.join(PPoutpath,'NEIDsortedStars.txt'), 'w') as g: #Write to file
             g.write('\n'.join(outString))
 
-        #while len(starNamesDat.keys() > 0):
-        #    with open
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Create a set of scripts and a queue. all files are relocated to a new folder.")

--- a/EXOSIMS/util/collateAllUniqueDetections.py
+++ b/EXOSIMS/util/collateAllUniqueDetections.py
@@ -102,7 +102,7 @@ class collateAllUniqueDetections(object):
                'starNames':[]}
 
         for counter,f in enumerate(pklfiles):
-            print "%d/%d"%(counter,len(pklfiles))
+            print("%d/%d"%(counter,len(pklfiles)))
             with open(f, 'rb') as g:
                 res = pickle.load(g)
 

--- a/EXOSIMS/util/evenlyDistributePointsOnSphere.py
+++ b/EXOSIMS/util/evenlyDistributePointsOnSphere.py
@@ -7,7 +7,7 @@ This code creates a set of n points on a unit sphere which are approximately spa
 
 from numpy import pi, cos, sin, arccos, arange
 import os
-if not 'DISPLAY' in os.environ.keys(): #Check environment for keys
+if not 'DISPLAY' in os.environ: #Check environment for keys
     import matplotlib.pyplot as pp 
     use('Agg')
 import mpl_toolkits.mplot3d

--- a/EXOSIMS/util/get_module.py
+++ b/EXOSIMS/util/get_module.py
@@ -38,7 +38,6 @@ def modules_below_matching(pkg, name):
     for _, modname, is_pkg in pkgutil.walk_packages(root_pkg.__path__, prefix):
         # skip packages: they are one up from the level we want
         if is_pkg: continue
-        # print "Found %s -- %s" % (modname, "pkg" if is_pkg else "not-pkg")
         if modname.endswith(name):
             modules.append(modname)
     return modules
@@ -114,7 +113,7 @@ def get_module_in_package(name, folder):
         #       i.e., the leading dot allows selection of this case, for very flat local module hierarchies,
         #       but the dot is removed before searching.
         if _verbose:
-            print 'get_module: case 3: attempting to load <%s>' % name
+            print('get_module: case 3: attempting to load <%s>' % name)
         # kill leading ., if any
         module_names = [ name.lstrip('.') ]
     elif folder is not None:
@@ -122,7 +121,7 @@ def get_module_in_package(name, folder):
         #    -- first: EXOSIMS.Prototypes.name
         #    -- fallback: EXOSIMS.folder.name
         if _verbose:
-            print 'get_module: case 2a: attempting to load <%s> from <%s>' % (name, folder)
+            print('get_module: case 2a: attempting to load <%s> from <%s>' % (name, folder))
 
         # load from Prototype, using asked-for module type, if name is empty or just blanks
         if len(name.strip(' ')) == 0:
@@ -136,7 +135,7 @@ def get_module_in_package(name, folder):
                 ]
     else:
         if _verbose:
-            print 'get_module: case 2b: attempting to load <%s>' % name
+            print('get_module: case 2b: attempting to load <%s>' % name)
         # Case 2b: folder NOT given
         #   -- first: EXOSIMS.Prototypes.name
         #   -- fallback: EXOSIMS.*.name
@@ -217,7 +216,7 @@ def get_module(name, folder = None):
     if name.endswith('.py'):
         # Case 1: module name is given as a path
         if _verbose:
-            print 'get_module: Case 1: attempting to load <%s>' % name
+            print('get_module: Case 1: attempting to load <%s>' % name)
         # expand ~/..., $HOME/..., etc.
         path = os.path.normpath(os.path.expandvars(os.path.expanduser(name)))
         if not os.path.isfile(path):
@@ -246,7 +245,7 @@ def get_module(name, folder = None):
     # ensure the extracted object is a class
     assert inspect.isclass(desired_module), \
       "Module contains an attribute %s but it is not a class." % module_name
-    print 'Imported %s (%s module) from %s' % (module_name, note, shorten_name(source))
+    print('Imported %s (%s module) from %s' % (module_name, note, shorten_name(source)))
     # validate the _modtype property of the module we just loaded
     assert hasattr(desired_module, '_modtype'), \
             "Module lacks attribute _modtype.  This is not a valid EXOSIMS class."

--- a/EXOSIMS/util/keplerSTM.py
+++ b/EXOSIMS/util/keplerSTM.py
@@ -101,12 +101,12 @@ class planSys:
                 self.updateState(tmp)
                 return
             except:
-                print "Cython propagation failed.  Falling back to python."
+                print("Cython propagation failed.  Falling back to python.")
 
         try:
             Phi = self.algOrder[0](dt)
         except ValueError as detail:
-            print "First algorithm error: %s\n Trying second algorithm."%(detail)
+            print("First algorithm error: %s\n Trying second algorithm."%(detail))
             Phi = self.algOrder[1](dt)
         
         self.updateState(np.dot(Phi,self.x0))

--- a/EXOSIMS/util/read_ipcluster_ensemble.py
+++ b/EXOSIMS/util/read_ipcluster_ensemble.py
@@ -52,7 +52,7 @@ def gen_summary(run_dir, includeUniversePlanetPop=False):
            'rs':[]}
 
     for counter,f in enumerate(pklfiles):
-        print "%d/%d"%(counter,len(pklfiles))
+        print("%d/%d"%(counter,len(pklfiles)))
         with open(f, 'rb') as g:
             res = pickle.load(g)
 
@@ -105,7 +105,7 @@ def read_all(run_dir):
     allres = []
 
     for counter,f in enumerate(pklfiles):
-        print "%d/%d"%(counter,len(pklfiles))
+        print("%d/%d"%(counter,len(pklfiles)))
         with open(f, 'rb') as g:
             res = pickle.load(g)
         allres.append(res)

--- a/EXOSIMS/util/runPostProcessing.py
+++ b/EXOSIMS/util/runPostProcessing.py
@@ -13,7 +13,7 @@ Written By: Dean Keithly
 Written On: 9/10/2018
 """
 import os
-if not 'DISPLAY' in os.environ.keys(): #Check environment for keys
+if not 'DISPLAY' in os.environ: #Check environment for keys
     from matplotlib import *
     use('Agg')
 from pylab import *
@@ -161,9 +161,9 @@ def queuePostProcessing(queueFileFolder):
     #####################################################################################################
 
     #### Run SRPP and MRPP ##############################################################################
-    if "singleRunPostProcessing" in queueData.keys():
+    if "singleRunPostProcessing" in queueData:
         SRPPsuccess = singleRunPostProcessing(queueData["singleRunPostProcessing"],PPoutpath,outpath,scriptNames)
-    if "multiRunPostProcessing" in queueData.keys():
+    if "multiRunPostProcessing" in queueData:
         MRPPsuccess = multiRunPostProcessing(queueData["multiRunPostProcessing"],PPoutpath,outpath,scriptNames)
 
     return True

--- a/EXOSIMS/util/runPostProcessing.py
+++ b/EXOSIMS/util/runPostProcessing.py
@@ -51,7 +51,7 @@ def singleRunPostProcessing(SRPPdat,PPoutpath,outpath,scriptNames):
         analysisScriptNameCORE = analysisScriptName.split('.')[0]
         module[analysisScriptName] = get_module.get_module(analysisScriptName,'util')
         #DELETE module['analysisScriptNameCORE'] = importlib.import_module(analysisScriptNameCORE)
-        if SRPPdat[i].has_key('args'):
+        if 'args' in SRPPdat[i]:
             args = SRPPdat[i]['args']
         else:
             args = {}
@@ -97,7 +97,7 @@ def multiRunPostProcessing(MRPPdat,PPoutpath,outpath,scriptNames):
         analysisScriptNameCORE = analysisScriptName.split('.')[0]
         module[analysisScriptName] = get_module.get_module(analysisScriptName,'util')
         #DELETE module['analysisScriptNameCORE'] = importlib.import_module(analysisScriptNameCORE)
-        if MRPPdat[i].has_key('args'):
+        if 'args' in MRPPdat[i]:
             args = MRPPdat[i]['args']
         else:
             args = {}

--- a/EXOSIMS/util/statsFun.py
+++ b/EXOSIMS/util/statsFun.py
@@ -42,7 +42,7 @@ def simpSample(f, numTest, xMin, xMax, M = None, verb = False):
         raise Exception("Failed to converge.")
     
     if verb:
-        print 'Finished in '+repr(numIter)+' iterations.'
+        print('Finished in '+repr(numIter)+' iterations.')
     
     return X
 

--- a/EXOSIMS/util/vprint.py
+++ b/EXOSIMS/util/vprint.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-import numpy as np
+
 
 def vprint(verbose):
     """This function is equivalent to the python print function, with an extra boolean

--- a/tests/BackgroundSources/test_BackgroundSources.py
+++ b/tests/BackgroundSources/test_BackgroundSources.py
@@ -12,7 +12,12 @@ from EXOSIMS.Prototypes.TargetList import TargetList
 import numpy as np
 import astropy.units as u
 import sys
-import StringIO
+
+# Python 3 compatibility:
+if sys.version_info[0] > 2:
+    from io import StringIO
+else:
+    from StringIO import StringIO
 
 class TestBackgroundSources(unittest.TestCase):
     """
@@ -26,7 +31,6 @@ class TestBackgroundSources(unittest.TestCase):
     """
 
     def setUp(self):
-
         self.dev_null = open(os.devnull, 'w')
         modtype = getattr(EXOSIMS.Prototypes.BackgroundSources.BackgroundSources,'_modtype')
         pkg = EXOSIMS.BackgroundSources
@@ -38,7 +42,8 @@ class TestBackgroundSources(unittest.TestCase):
                 self.allmods.append(mod)
         # need a TargetList object for testing
         script = resource_path('test-scripts/template_prototype_testing.json')
-        spec = json.loads(open(script).read())
+        with open(script) as f:
+            spec = json.loads(f.read())
         with RedirectStreams(stdout=self.dev_null):
             self.TL = TargetList(**spec)
 
@@ -68,7 +73,8 @@ class TestBackgroundSources(unittest.TestCase):
             with RedirectStreams(stdout=self.dev_null):
                 obj = mod()
             original_stdout = sys.stdout
-            sys.stdout = StringIO.StringIO()
+            # sys.stdout = StringIO.StringIO()
+            sys.stdout = StringIO()
             # call __str__ method
             result = obj.__str__()
             # examine what was printed
@@ -79,4 +85,3 @@ class TestBackgroundSources(unittest.TestCase):
             self.assertEqual(type(result), type(''))
             # put stdout back
             sys.stdout = original_stdout
-

--- a/tests/Completeness/test_BrownvGarrett.py
+++ b/tests/Completeness/test_BrownvGarrett.py
@@ -35,7 +35,7 @@ class TestBrownvGarrett(unittest.TestCase):
         with RedirectStreams(stdout=self.dev_null):
             TL = TargetList(ntargs=100,**copy.deepcopy(self.spec))
 
-            mode = filter(lambda mode: mode['detectionMode'] == True, TL.OpticalSystem.observingModes)[0]
+            mode = list(filter(lambda mode: mode['detectionMode'] == True, TL.OpticalSystem.observingModes))[0]
             IWA = mode['IWA']
             OWA = mode['OWA']
             rrange = TL.PlanetPopulation.rrange
@@ -77,7 +77,7 @@ class TestBrownvGarrett(unittest.TestCase):
         with RedirectStreams(stdout=self.dev_null):
             TL = TargetList(ntargs=100,constrainOrbits=True,**copy.deepcopy(self.spec))
 
-            mode = filter(lambda mode: mode['detectionMode'] == True, TL.OpticalSystem.observingModes)[0]
+            mode = list(filter(lambda mode: mode['detectionMode'] == True, TL.OpticalSystem.observingModes))[0]
             IWA = mode['IWA']
             OWA = mode['OWA']
             rrange = TL.PlanetPopulation.rrange

--- a/tests/Completeness/test_BrownvGarrett.py
+++ b/tests/Completeness/test_BrownvGarrett.py
@@ -23,7 +23,8 @@ class TestBrownvGarrett(unittest.TestCase):
 
         self.dev_null = open(os.devnull, 'w')
         self.script = resource_path('test-scripts/template_minimal.json')
-        self.spec = json.loads(open(self.script).read())
+        with open(self.script) as f:
+            self.spec = json.loads(f.read())
         
 
     def test_target_completeness_def(self):

--- a/tests/Completeness/test_Completeness.py
+++ b/tests/Completeness/test_Completeness.py
@@ -12,7 +12,12 @@ import astropy.units as u
 import json
 import copy
 import sys
-import StringIO
+
+# Python 3 compatibility:
+if sys.version_info[0] > 2:
+    from io import StringIO
+else:
+    from StringIO import StringIO
 
 class TestCompleteness(unittest.TestCase):
     """ 
@@ -29,7 +34,8 @@ class TestCompleteness(unittest.TestCase):
 
         self.dev_null = open(os.devnull, 'w')
         self.script = resource_path('test-scripts/template_minimal.json')
-        self.spec = json.loads(open(self.script).read())
+        with open(self.script) as f:
+            self.spec = json.loads(f.read())
         
         with RedirectStreams(stdout=self.dev_null):
             self.TL = TargetList(ntargs=10,**copy.deepcopy(self.spec))
@@ -184,7 +190,7 @@ class TestCompleteness(unittest.TestCase):
             with RedirectStreams(stdout=self.dev_null):
                 obj = mod(**copy.deepcopy(self.spec))
             original_stdout = sys.stdout
-            sys.stdout = StringIO.StringIO()
+            sys.stdout = StringIO()
             # call __str__ method
             result = obj.__str__()
             # examine what was printed

--- a/tests/Completeness/test_GarrettCompleteness.py
+++ b/tests/Completeness/test_GarrettCompleteness.py
@@ -18,12 +18,14 @@ class TestGarrettCompleteness(unittest.TestCase):
 
         self.dev_null = open(os.devnull, 'w')
         self.script = resource_path('test-scripts/template_minimal.json')
-        self.spec = json.loads(open(self.script).read())
+        with open(self.script) as f:
+            self.spec = json.loads(f.read())
         self.spec['modules']['PlanetPopulation'] = 'AlbedoByRadius'
         self.spec['prange'] = [0.1,0.5]
         self.spec['Rprange'] = [1,10]
         self.script2 = resource_path('test-scripts/simplest.json')
-        self.spec2 = json.loads(open(self.script2).read())
+        with open(self.script2) as f:
+            self.spec2 = json.loads(f.read())
 
     def test_calcs(self):
         """

--- a/tests/Observatory/test_Observatory.py
+++ b/tests/Observatory/test_Observatory.py
@@ -9,7 +9,12 @@ import numpy as np
 from astropy.time import Time
 import astropy.units as u
 from tests.TestSupport.Utilities import RedirectStreams
-import StringIO
+
+# Python 3 compatibility:
+if sys.version_info[0] > 2:
+    from io import StringIO
+else:
+    from StringIO import StringIO
 
 
 class TestObservatory(unittest.TestCase):
@@ -29,7 +34,8 @@ class TestObservatory(unittest.TestCase):
 
         # self.spec = {"modules": {"PlanetPhysicalModel": "PlanetPhysicalModel"}}
         self.script = resource_path('test-scripts/template_minimal.json')
-        self.spec = json.loads(open(self.script).read())
+        with open(self.script) as f:
+            self.spec = json.loads(f.read())
 
         modtype = getattr(EXOSIMS.Prototypes.Observatory.Observatory, '_modtype')
         pkg = EXOSIMS.Observatory
@@ -121,7 +127,7 @@ class TestObservatory(unittest.TestCase):
                 else:
                     obj = mod(**copy.deepcopy(self.spec))
             original_stdout = sys.stdout
-            sys.stdout = StringIO.StringIO()
+            sys.stdout = StringIO()
             # call __str__ method
             result = obj.__str__()
             # examine what was printed

--- a/tests/Observatory/test_Observatory.py
+++ b/tests/Observatory/test_Observatory.py
@@ -101,7 +101,7 @@ class TestObservatory(unittest.TestCase):
                 DRM = obj.log_occulterResults(DRM, slewTimes, sInds, sd, dV)
 
                 for att in atts_list:
-                    self.assertTrue(att in DRM.keys(), 'Missing key in log_occulterResults for %s' % mod.__name__)
+                    self.assertTrue(att in DRM, 'Missing key in log_occulterResults for %s' % mod.__name__)
 
     def test_str(self):
         """

--- a/tests/PlanetPhysicalModel/test_PlanetPhysicalModel.py
+++ b/tests/PlanetPhysicalModel/test_PlanetPhysicalModel.py
@@ -8,7 +8,12 @@ from tests.TestSupport.Utilities import RedirectStreams
 import numpy as np
 import astropy.units as u
 import sys
-import StringIO
+
+# Python 3 compatibility:
+if sys.version_info[0] > 2:
+    from io import StringIO
+else:
+    from StringIO import StringIO
 
 class TestPlanetPhysicalModel(unittest.TestCase):
     def setUp(self):
@@ -118,7 +123,7 @@ class TestPlanetPhysicalModel(unittest.TestCase):
             with RedirectStreams(stdout=self.dev_null):
                 obj = mod()
             original_stdout = sys.stdout
-            sys.stdout = StringIO.StringIO()
+            sys.stdout = StringIO()
             # call __str__ method
             result = obj.__str__()
             # examine what was printed

--- a/tests/PlanetPopulation/test_DulzPlavchan.py
+++ b/tests/PlanetPopulation/test_DulzPlavchan.py
@@ -1,17 +1,10 @@
 import unittest
 from EXOSIMS.PlanetPopulation.DulzPlavchan import DulzPlavchan
-import EXOSIMS
-import EXOSIMS.Prototypes.PlanetPopulation
-import EXOSIMS.PlanetPopulation
-import pkgutil
-from EXOSIMS.util.get_module import get_module
 from tests.TestSupport.Info import resource_path
 import numpy as np
 import os
 from tests.TestSupport.Utilities import RedirectStreams
 import copy
-import sys
-import StringIO
 
 class TestDulzPlavchan(unittest.TestCase):
     """

--- a/tests/PlanetPopulation/test_KnownRVPlanets.py
+++ b/tests/PlanetPopulation/test_KnownRVPlanets.py
@@ -15,7 +15,6 @@ import sys
 import os
 import json
 import logging
-import StringIO
 import unittest
 from EXOSIMS.PlanetPopulation.KnownRVPlanets import KnownRVPlanets
 import numpy as np

--- a/tests/PlanetPopulation/test_KnownRVPlanets.py
+++ b/tests/PlanetPopulation/test_KnownRVPlanets.py
@@ -116,7 +116,7 @@ class TestKnownRVPlanetsMethods(unittest.TestCase):
             for (key,value) in plan_pop.__dict__.items():
                 if key == 'allplanetdata': continue
                 if key == 'table': continue
-                print key, '==>', value
+                print(key, '==>', value)
 
     def test_init_file_no_file(self):
         r"""Test __init__ file handling -- various non-existent input files.

--- a/tests/PlanetPopulation/test_PlanetPopulation.py
+++ b/tests/PlanetPopulation/test_PlanetPopulation.py
@@ -8,7 +8,12 @@ import numpy as np
 import os
 from tests.TestSupport.Utilities import RedirectStreams
 import sys
-import StringIO
+
+# Python 3 compatibility:
+if sys.version_info[0] > 2:
+    from io import StringIO
+else:
+    from StringIO import StringIO
 
 class TestPlanetPopulation(unittest.TestCase):
     """ 
@@ -465,7 +470,7 @@ class TestPlanetPopulation(unittest.TestCase):
             with RedirectStreams(stdout=self.dev_null):
                 obj = mod(**self.spec)
             original_stdout = sys.stdout
-            sys.stdout = StringIO.StringIO()
+            sys.stdout = StringIO()
             # call __str__ method
             result = obj.__str__()
             # examine what was printed

--- a/tests/PostProcessing/test_PostProcessing.py
+++ b/tests/PostProcessing/test_PostProcessing.py
@@ -13,7 +13,12 @@ from tests.TestSupport.Info import resource_path
 import astropy.units as u
 import inspect
 import sys
-import StringIO
+
+# Python 3 compatibility:
+if sys.version_info[0] > 2:
+    from io import StringIO
+else:
+    from StringIO import StringIO
 
 class TestPostProcessing(unittest.TestCase):
     """ 
@@ -31,7 +36,8 @@ class TestPostProcessing(unittest.TestCase):
         self.dev_null = open(os.devnull, 'w')
         self.specs = {'modules':{'BackgroundSources':' '}}
         script = resource_path('test-scripts/template_minimal.json')
-        spec = json.loads(open(script).read())     
+        with open(script) as f:
+            spec = json.loads(f.read())
         with RedirectStreams(stdout=self.dev_null):
             self.TL = TargetList(**spec)
 
@@ -125,7 +131,7 @@ class TestPostProcessing(unittest.TestCase):
             with RedirectStreams(stdout=self.dev_null):
                 obj = mod(**self.specs)
             original_stdout = sys.stdout
-            sys.stdout = StringIO.StringIO()
+            sys.stdout = StringIO()
             # call __str__ method
             result = obj.__str__()
             # examine what was printed

--- a/tests/Prototypes/test_Completeness.py
+++ b/tests/Prototypes/test_Completeness.py
@@ -1,12 +1,8 @@
 import unittest
-import numpy as np
-import os
-import EXOSIMS
 from EXOSIMS.Prototypes import Completeness
 import numpy as np
 import astropy.units as u
-import sys
-import StringIO
+
 
 class Test_Completeness_Prototype(unittest.TestCase):
     """
@@ -91,21 +87,3 @@ class Test_Completeness_Prototype(unittest.TestCase):
         
         self.assertTrue(Comp.PlanetPopulation.__class__.__name__=='PlanetPopulation',"empty completeness_specs did not load prototype PlanetPopulation")
         self.assertTrue(Comp.PlanetPhysicalModel.__class__.__name__=='PlanetPhysicalModel',"empty completeness_specs did not load prototype PlanetPhysicalModel")
-            
-    def test_str(self):
-        r"""Test __str__ method, for full coverage."""
-
-        original_stdout = sys.stdout
-        sys.stdout = StringIO.StringIO()
-        # call __str__ method
-        result = self.fixture.__str__()
-        # examine what was printed
-        contents = sys.stdout.getvalue()
-        self.assertEqual(type(contents), type(''))
-        self.assertIn('dMagLim', contents)
-        self.assertIn('minComp', contents)
-        sys.stdout.close()
-        # it also returns a string, which is not necessary
-        self.assertEqual(type(result), type(''))
-        # put stdout back
-        sys.stdout = original_stdout

--- a/tests/Prototypes/test_Observatory.py
+++ b/tests/Prototypes/test_Observatory.py
@@ -41,7 +41,7 @@ class TestObservatoryMethods(unittest.TestCase):
         so no real check is applicable.
         """
 
-        print 'keepout()'
+        print('keepout()')
         class MockStarCatalog(object):
             r"""Micro-catalog containing stars for testing.
 
@@ -83,7 +83,7 @@ class TestObservatoryMethods(unittest.TestCase):
         Approach: Probes for a range of inputs.
         """
 
-        print 'cent()'
+        print('cent()')
         obs = self.fixture
         # origin at 12:00 on 2000.Jan.01
         t_ref_string = '2000-01-01T12:00:00.0'
@@ -108,7 +108,7 @@ class TestObservatoryMethods(unittest.TestCase):
         Approach: Reference to pre-computed result from Matlab.
         """
 
-        print 'moon_earth()'
+        print('moon_earth()')
         obs = self.fixture
         # TODO: add other times besides this one
         # century = 0
@@ -128,7 +128,7 @@ class TestObservatoryMethods(unittest.TestCase):
         Approach: Reference to result computed by external ephemeris.
         """
 
-        print 'keplerplanet()'
+        print('keplerplanet()')
         obs = self.fixture 
         # JPL ephemeris spice kernel data
         #   this is from: http://naif.jpl.nasa.gov/pub/naif/generic_kernels/spk/planets/
@@ -207,7 +207,7 @@ class TestObservatoryMethods(unittest.TestCase):
         (2) Randomized probes ensuring that R(axis,-theta) * R(axis,+theta) = I,
         but cumulated over many probes."""
 
-        print 'rot()'
+        print('rot()')
         obs = self.fixture
 
         # rotation(0) = identity

--- a/tests/Prototypes/test_Observatory.py
+++ b/tests/Prototypes/test_Observatory.py
@@ -9,9 +9,7 @@ r"""Observatory module unit tests
 Michael Turmon, JPL, Feb. 2016
 """
 
-import sys
 import unittest
-import StringIO
 from EXOSIMS.Prototypes.Observatory import Observatory
 from EXOSIMS.util.get_dirs import get_downloads_dir
 import os

--- a/tests/Prototypes/test_OpticalSystem.py
+++ b/tests/Prototypes/test_OpticalSystem.py
@@ -490,13 +490,13 @@ class TestOpticalSystemMethods(unittest.TestCase):
         r"""Compare two _outspec dictionaries.
 
         This is in service of the roundtrip comparison, test_roundtrip."""
-        self.assertEqual(sorted(outspec1.keys()), sorted(outspec2.keys()))
-        for k in outspec1.keys():
+        self.assertEqual(sorted(list(outspec1)), sorted(list(outspec2)))
+        for k in outspec1:
             if isinstance(outspec1[k], list):
                 # this happens for scienceInstrument and starlightSuppression,
                 # which are lists of dictionaries
                 for (d1, d2) in zip(outspec1[k], outspec2[k]):
-                    for kk in d1.keys():
+                    for kk in d1:
                         self.assertEqual(d1[kk], d2[kk])
             else:
                 # these are strings or numbers, but not Quantity's,
@@ -602,7 +602,7 @@ class TestOpticalSystemMethods(unittest.TestCase):
                                             ' -- type mismatch: %d vs %d' % (type(d1), type(d2)))
             assert isinstance(d2, dict), msg + " -- compare_lists expects lists-of-dicts"
             # note: we need d2 to be a subset of d1
-            for k in d2.keys():
+            for k in d2:
                 self.assertEqual(d1[k], d2[k], msg + ' -- key %s mismatch' % k)
 
     @unittest.skip('All of these need to be tested separately')        

--- a/tests/Prototypes/test_OpticalSystem.py
+++ b/tests/Prototypes/test_OpticalSystem.py
@@ -675,8 +675,8 @@ class TestOpticalSystemMethods(unittest.TestCase):
                     else:
                         # a number or Quantity - simple assertion
                         if isinstance(param_val, list):
-                            print '***', param
-                            print d[param]
+                            print('***', param)
+                            print(d[param])
                         self.assertEqual(d[param], param_val*unit,
                                          msg='failed to set "%s" parameter' % param)
                 else:

--- a/tests/Prototypes/test_OpticalSystem.py
+++ b/tests/Prototypes/test_OpticalSystem.py
@@ -22,6 +22,10 @@ from tests.TestSupport.Info import resource_path
 import numpy as np
 import astropy.units as u
 
+# Python 3 compatibility:
+if sys.version_info[0] > 2:
+    basestring = str
+
 #
 # A few specs dictionaries that can be used to instantiate OpticalSystem objects
 #

--- a/tests/Prototypes/test_OpticalSystem.py
+++ b/tests/Prototypes/test_OpticalSystem.py
@@ -15,7 +15,6 @@ import re
 import numbers
 import unittest
 import inspect
-import StringIO
 from copy import deepcopy
 from EXOSIMS.Prototypes.OpticalSystem import OpticalSystem
 from tests.TestSupport.Info import resource_path
@@ -297,7 +296,7 @@ class TestOpticalSystemMethods(unittest.TestCase):
             self.assertIn(att, optsys.__dict__)
             self.assertIsNotNone(optsys.__dict__[att])
         # optionally, check against a supplied reference dictionary
-        for (att,val) in spec.iteritems():
+        for (att,val) in spec.items():
             self.assertIn(att, optsys.__dict__)
             val_e = optsys.__dict__[att]
             if isinstance(val_e, u.quantity.Quantity):
@@ -687,27 +686,6 @@ class TestOpticalSystemMethods(unittest.TestCase):
                     # else, ensure the right error is raised
                     with self.assertRaises(err_val):
                         self.fixture(**deepcopy(specs))
-            
-    def test_str(self):
-        r"""Test __str__ method, for full coverage."""
-        optsys = self.fixture(**deepcopy(specs_default))
-        self.validate_basic(optsys, specs_default)
-        # replace stdout and keep a reference
-        original_stdout = sys.stdout
-        sys.stdout = StringIO.StringIO()
-        # call __str__ method
-        result = optsys.__str__()
-        # examine what was printed
-        contents = sys.stdout.getvalue()
-        self.assertEqual(type(contents), type(''))
-        self.assertIn('IWA', contents)
-        self.assertIn('OWA', contents)
-        self.assertIn('dMag0', contents)
-        sys.stdout.close()
-        # it also returns a string, which is not necessary
-        self.assertEqual(type(result), type(''))
-        # put stdout back
-        sys.stdout = original_stdout
 
 
 if __name__ == '__main__':

--- a/tests/Prototypes/test_SurveySimulation.py
+++ b/tests/Prototypes/test_SurveySimulation.py
@@ -179,8 +179,8 @@ class TestSurveySimulationMethods(unittest.TestCase):
         with open(out_filename, 'r') as fp:
             outspec_new = json.load(fp)
         # ensure all keys are present
-        self.assertListEqual(sorted(outspec_orig.keys()),
-                             sorted(outspec_new.keys()))
+        self.assertListEqual(sorted(list(outspec_orig)),
+                             sorted(list(outspec_new)))
         # furthermore, ensure the re-loaded outspec is OK
         # this is a rather stringent test
         self.validate_outspec(outspec_new, sim)

--- a/tests/Prototypes/test_SurveySimulation.py
+++ b/tests/Prototypes/test_SurveySimulation.py
@@ -14,16 +14,12 @@ Michael Turmon, JPL, Apr. 2016
 import sys
 import os
 import unittest
-import StringIO
 import json
-from collections import namedtuple
 from EXOSIMS.Prototypes.SurveySimulation import SurveySimulation
 import numpy as np
 import astropy.units as u
-from astropy.time import Time
 from tests.TestSupport.Info import resource_path
 from tests.TestSupport.Utilities import RedirectStreams
-import pdb
 
 SimpleScript = resource_path('test-scripts/simplest.json')
 ErrorScript = resource_path('test-scripts/simplest-error.json')
@@ -44,26 +40,6 @@ class TestSurveySimulationMethods(unittest.TestCase):
     def tearDown(self):
         del self.fixture
 
-
-    def test_str(self):
-        r"""Test __str__ method, for full coverage."""
-        with RedirectStreams(stdout=self.dev_null):
-            sim = self.fixture(SimpleScript)
-        # replace stdout and keep a reference
-        original_stdout = sys.stdout
-        sys.stdout = StringIO.StringIO()
-        # call __str__ method
-        result = sim.__str__()
-        # examine what was printed
-        contents = sys.stdout.getvalue()
-        self.assertEqual(type(contents), type(''))
-        self.assertIn('DRM', contents)
-        sys.stdout.close()
-        # it also returns a string, which is not necessary
-        self.assertEqual(type(result), type(''))
-        # put stdout back
-        sys.stdout = original_stdout
-
     def test_init_fail(self):
         r"""Test of initialization and __init__ -- failure.
         """
@@ -74,7 +50,9 @@ class TestSurveySimulationMethods(unittest.TestCase):
     def test_init_specs(self):
         r"""Test of initialization and __init__ -- specs dictionary.
         """
-        script = open(SimpleScript).read()
+        with open(SimpleScript) as f:
+            script = f.read()
+        # script = open(SimpleScript).read()
         specs = json.loads(script)
         with RedirectStreams(stdout=self.dev_null):
             sim = self.fixture(scriptfile=None, **specs)

--- a/tests/Prototypes/test_TargetList.py
+++ b/tests/Prototypes/test_TargetList.py
@@ -1,15 +1,12 @@
 import unittest
-import numpy as np
 import os
-import EXOSIMS
-from  EXOSIMS import MissionSim
+from EXOSIMS import MissionSim
 from EXOSIMS.Prototypes import TargetList
 import numpy as np
 from astropy import units as u
 from tests.TestSupport.Info import resource_path
 from tests.TestSupport.Utilities import RedirectStreams
 import json
-import copy
 
 r"""TargetList module unit tests
 
@@ -22,7 +19,8 @@ class Test_TargetList_prototype(unittest.TestCase):
     dev_null = open(os.devnull, 'w')
 
     def setUp(self):
-        self.spec = json.loads(open(scriptfile).read())
+        with open(scriptfile) as f:
+            self.spec = json.loads(f.read())
         
         # quiet the chatter at initialization
         with RedirectStreams(stdout=self.dev_null):
@@ -241,7 +239,8 @@ class Test_TargetList_prototype(unittest.TestCase):
         self.assertEqual(self.targetlist.PlanetPopulation.__class__.__name__,self.targetlist.Completeness.PlanetPopulation.__class__.__name__)
         
         # test case where completeness specs given
-        spec2 = json.loads(open(scriptfile).read())
+        with open(scriptfile) as f:
+            spec2 = json.loads(f.read())
         spec2['completeness_specs'] = {'modules': {"PlanetPopulation": "EarthTwinHabZone1", \
              "PlanetPhysicalModel": "PlanetPhysicalModel"}}
         spec2['explainFiltering'] = True

--- a/tests/Prototypes/test_TimeKeeping.py
+++ b/tests/Prototypes/test_TimeKeeping.py
@@ -262,7 +262,7 @@ class TestTimeKeepingMethods(unittest.TestCase):
         allModes = sim.OpticalSystem.observingModes
         Obs = sim.Observatory
         OS = sim.OpticalSystem
-        det_mode = filter(lambda mode: mode['detectionMode'] == True, allModes)[0]
+        det_mode = list(filter(lambda mode: mode['detectionMode'] == True, allModes))[0]
 
         # 1) mission not over
         tk.exoplanetObsTime = 0*u.d
@@ -631,7 +631,7 @@ class TestTimeKeepingMethods(unittest.TestCase):
         sim = self.allmods[0](scriptfile=self.script1)
         allModes = sim.OpticalSystem.observingModes
         Obs = sim.Observatory
-        mode = filter(lambda mode: mode['detectionMode'] == True, allModes)[0]
+        mode = list(filter(lambda mode: mode['detectionMode'] == True, allModes))[0]
 
         # 1) Does returned times enable allocation to succeed
         tk.currentTimeNorm = 0*u.d

--- a/tests/Prototypes/test_TimeKeeping.py
+++ b/tests/Prototypes/test_TimeKeeping.py
@@ -11,14 +11,7 @@ Michael Turmon, JPL, Mar/Apr 2016
 
 import sys
 import unittest
-import StringIO
-from collections import namedtuple
-import EXOSIMS.OpticalSystem
-import EXOSIMS.SurveySimulation
-import pkgutil
 from EXOSIMS.Prototypes.TimeKeeping import TimeKeeping
-from EXOSIMS.Prototypes.Observatory import Observatory
-from EXOSIMS.Prototypes.OpticalSystem import OpticalSystem
 from tests.TestSupport.Utilities import RedirectStreams
 from EXOSIMS.Prototypes.SurveySimulation import SurveySimulation
 from tests.TestSupport.Info import resource_path
@@ -26,8 +19,12 @@ from EXOSIMS.util.get_module import get_module
 import os
 import numpy as np
 import astropy.units as u
-from astropy.time import Time
-import pdb
+
+# Python 3 compatibility:
+if sys.version_info[0] > 2:
+    from io import StringIO
+else:
+    from StringIO import StringIO
 
 class TestTimeKeepingMethods(unittest.TestCase):
     r"""Test TimeKeeping class."""
@@ -83,7 +80,7 @@ class TestTimeKeepingMethods(unittest.TestCase):
         tk = self.fixture()
         # replace stdout and keep a reference
         original_stdout = sys.stdout
-        sys.stdout = StringIO.StringIO()
+        sys.stdout = StringIO()
         # call __str__ method
         result = tk.__str__()
         # examine what was printed

--- a/tests/SimulatedUniverse/test_KnownRVPlanetsUniverse.py
+++ b/tests/SimulatedUniverse/test_KnownRVPlanetsUniverse.py
@@ -16,15 +16,11 @@ import os
 import unittest
 import warnings
 import json
-import StringIO
 from collections import namedtuple
 from EXOSIMS.SimulatedUniverse.KnownRVPlanetsUniverse import KnownRVPlanetsUniverse
 import numpy as np
 import astropy.units as u
-from astropy.time import Time
-from tests.TestSupport.Info import resource_path
 from tests.TestSupport.Utilities import RedirectStreams
-from tests.TestSupport.Utilities import load_vo_csvfile
 
 # A JSON string containing KnownRVPlanets - from simplest-old.json
 # The part we require is the "modules" dictionary.
@@ -236,27 +232,6 @@ class TestKnownRVPlanetsUniverseMethods(unittest.TestCase):
         # range: 0 <= plan2star < nStars
         self.assertEqual(0, np.count_nonzero(universe.plan2star < 0))
         self.assertEqual(0, np.count_nonzero(universe.plan2star >= universe.TargetList.nStars))
-
-    # @unittest.skip("Skipping str.")
-    def test_str(self):
-        r"""Test __str__ method, for full coverage."""
-        universe = self.fixture
-        # replace stdout and keep a reference
-        original_stdout = sys.stdout
-        sys.stdout = StringIO.StringIO()
-        # call __str__ method
-        result = universe.__str__()
-        # examine what was printed
-        contents = sys.stdout.getvalue()
-        self.assertEqual(type(contents), type(''))
-        self.assertIn('PlanetPhysicalModel', contents)
-        self.assertIn('PlanetPopulation', contents)
-        self.assertIn('PostProcessing', contents)
-        sys.stdout.close()
-        # it also returns a string, which is not necessary
-        self.assertEqual(type(result), type(''))
-        # put stdout back
-        sys.stdout = original_stdout
 
     
 if __name__ == '__main__':

--- a/tests/SimulatedUniverse/test_SimulatedUniverse.py
+++ b/tests/SimulatedUniverse/test_SimulatedUniverse.py
@@ -288,7 +288,7 @@ class TestSimulatedUniverse(unittest.TestCase):
         
         test_dict = SU.dump_systems()
         for key in req_keys:
-            self.assertIn(key,test_dict.keys(),"Key %s not in dictionary produced by dump_systems"%key)
+            self.assertIn(key,test_dict,"Key %s not in dictionary produced by dump_systems"%key)
             if key not in matts:
                 self.assertTrue(np.all(test_dict[key] == getattr(SU,key)),"Value(s) for %s not same produced by dump_systems"%key)
 

--- a/tests/SimulatedUniverse/test_SimulatedUniverse.py
+++ b/tests/SimulatedUniverse/test_SimulatedUniverse.py
@@ -13,7 +13,12 @@ import astropy.constants as const
 import json
 import copy
 import sys
-import StringIO
+
+# Python 3 compatibility:
+if sys.version_info[0] > 2:
+    from io import StringIO
+else:
+    from StringIO import StringIO
 
 class TestSimulatedUniverse(unittest.TestCase):
     """ 
@@ -30,7 +35,8 @@ class TestSimulatedUniverse(unittest.TestCase):
 
         self.dev_null = open(os.devnull, 'w')
         self.script = resource_path('test-scripts/template_minimal.json')
-        self.spec = json.loads(open(self.script).read())
+        with open(self.script) as f:
+            self.spec = json.loads(f.read())
         
         with RedirectStreams(stdout=self.dev_null):
             self.TL = TargetList(ntargs=10,**copy.deepcopy(self.spec))
@@ -155,14 +161,16 @@ class TestSimulatedUniverse(unittest.TestCase):
         Test that fixed PlanPerStar flag passes through integers and None
         """
 
-        spec = json.loads(open(self.script).read())
+        with open(self.script) as f:
+            spec = json.loads(f.read())
         #If fixedPlanPerStar is not Defined
         SU = SimulatedUniverse(**spec)
         self.assertTrue(SU.fixedPlanPerStar==None)
 
         #For 1 star
         del SU
-        spec = json.loads(open(self.script).read())
+        with open(self.script) as f:
+            spec = json.loads(f.read())
         #If fixedPlanPerStar is defined
         spec['fixedPlanPerStar'] = 1
         SU = SimulatedUniverse(**spec)
@@ -173,7 +181,8 @@ class TestSimulatedUniverse(unittest.TestCase):
 
         #For a random integer of stars
         del SU
-        spec = json.loads(open(self.script).read())
+        with open(self.script) as f:
+            spec = json.loads(f.read())
         #If fixedPlanPerStar is defined
         n = np.random.randint(1,100)
 
@@ -282,7 +291,8 @@ class TestSimulatedUniverse(unittest.TestCase):
         
         # missing attributes from req_keys
         matts = ['mu','star']
-        spec = json.loads(open(self.script).read())
+        with open(self.script) as f:
+            spec = json.loads(f.read())
         spec['modules']['StarCatalog'] = 'EXOCAT1'
         SU = SimulatedUniverse(**spec)
         
@@ -297,7 +307,8 @@ class TestSimulatedUniverse(unittest.TestCase):
         Test that load systems loads correctly
         """
 
-        spec = json.loads(open(self.script).read())
+        with open(self.script) as f:
+            spec = json.loads(f.read())
         spec['modules']['StarCatalog'] = 'EXOCAT1'
         with RedirectStreams(stdout=self.dev_null):
             SU = SimulatedUniverse(**spec)
@@ -322,8 +333,9 @@ class TestSimulatedUniverse(unittest.TestCase):
         """
         Test that revise_planets_list filters correctly
         """
-        
-        spec = json.loads(open(self.script).read())
+
+        with open(self.script) as f:
+            spec = json.loads(f.read())
         spec['Rprange'] = [1,20]
         spec['modules']['StarCatalog'] = 'EXOCAT1'
         SU = SimulatedUniverse(**spec)
@@ -337,8 +349,9 @@ class TestSimulatedUniverse(unittest.TestCase):
         """
         Test that revise_stars_list filters correctly
         """
-        
-        spec = json.loads(open(self.script).read())
+
+        with open(self.script) as f:
+            spec = json.loads(f.read())
         spec['modules']['StarCatalog'] = 'EXOCAT1'
         spec['eta'] = 1
         SU = SimulatedUniverse(**spec)
@@ -387,7 +400,7 @@ class TestSimulatedUniverse(unittest.TestCase):
 
             obj = mod(**spec)
             original_stdout = sys.stdout
-            sys.stdout = StringIO.StringIO()
+            sys.stdout = StringIO()
             # call __str__ method
             result = obj.__str__()
             # examine what was printed

--- a/tests/StarCatalog/test_StarCatalog.py
+++ b/tests/StarCatalog/test_StarCatalog.py
@@ -5,7 +5,12 @@ from EXOSIMS.Prototypes.StarCatalog import StarCatalog
 from EXOSIMS.util.get_module import get_module
 import os, sys
 import pkgutil
-import StringIO
+
+# Python 3 compatibility:
+if sys.version_info[0] > 2:
+    from io import StringIO
+else:
+    from StringIO import StringIO
 
 class TestStarCatalog(unittest.TestCase):
     """ 
@@ -67,7 +72,7 @@ class TestStarCatalog(unittest.TestCase):
             with RedirectStreams(stdout=self.dev_null):
                 obj = mod()
             original_stdout = sys.stdout
-            sys.stdout = StringIO.StringIO()
+            sys.stdout = StringIO()
             # call __str__ method
             result = obj.__str__()
             # examine what was printed

--- a/tests/SurveySimulation/test_SurveySimulation.py
+++ b/tests/SurveySimulation/test_SurveySimulation.py
@@ -128,7 +128,7 @@ class TestSurveySimulation(unittest.TestCase):
                     sim.run_sim()
                     # check that a mission constraint has been exceeded
                     allModes = sim.OpticalSystem.observingModes
-                    mode = filter(lambda mode: mode['detectionMode'] == True, allModes)[0]
+                    mode = list(filter(lambda mode: mode['detectionMode'] == True, allModes))[0]
                     exoplanetObsTimeCondition = sim.TimeKeeping.exoplanetObsTime + sim.Observatory.settlingTime + mode['syst']['ohTime'] >= sim.TimeKeeping.missionLife*sim.TimeKeeping.missionPortion
                     missionLifeCondition = sim.TimeKeeping.currentTimeNorm + sim.Observatory.settlingTime + mode['syst']['ohTime'] >= sim.TimeKeeping.missionLife
                     OBcondition = sim.TimeKeeping.OBendTimes[sim.TimeKeeping.OBnumber] <= sim.TimeKeeping.currentTimeNorm + sim.Observatory.settlingTime + mode['syst']['ohTime']
@@ -254,7 +254,7 @@ class TestSurveySimulation(unittest.TestCase):
                     sim = mod(**spec)
                     startTimes = sim.TimeKeeping.currentTimeAbs.copy() + np.zeros(sim.TargetList.nStars)*u.d
                     sInds = np.arange(sim.TargetList.nStars)
-                    mode = filter(lambda mode: mode['detectionMode'] == True, sim.OpticalSystem.observingModes)[0]
+                    mode = list(filter(lambda mode: mode['detectionMode'] == True, sim.OpticalSystem.observingModes))[0]
                     intTimes = sim.calc_targ_intTime(sInds, startTimes, mode)
                 self.assertTrue(len(intTimes) == len(sInds), 'calc_targ_intTime returns incorrect number of intTimes for %s'%mod.__name__)
                 self.assertTrue(intTimes.unit == u.d, 'calc_targ_intTime returns incorrect unit for %s'%mod.__name__)

--- a/tests/SurveySimulation/test_SurveySimulation.py
+++ b/tests/SurveySimulation/test_SurveySimulation.py
@@ -142,10 +142,10 @@ class TestSurveySimulation(unittest.TestCase):
 
                 if 'det_only' in mod.__name__:
                     for key in det_only_DRM_keys:
-                        self.assertIn(key,sim.DRM[0].keys(),'DRM is missing key %s for %s'%(key,mod.__name__))
+                        self.assertIn(key,sim.DRM[0],'DRM is missing key %s for %s'%(key,mod.__name__))
                 else:
                     for key in All_DRM_keys:
-                        self.assertIn(key,sim.DRM[0].keys(),'DRM is missing key %s for %s'%(key,mod.__name__))
+                        self.assertIn(key,sim.DRM[0],'DRM is missing key %s for %s'%(key,mod.__name__))
    
     def test_next_target(self):
         r"""Test next_target method.

--- a/tests/TargetList/test_KnownRVPlanetsTargetList.py
+++ b/tests/TargetList/test_KnownRVPlanetsTargetList.py
@@ -16,7 +16,6 @@ import os
 import unittest
 import warnings
 import json
-import StringIO
 from collections import namedtuple
 from EXOSIMS.TargetList.KnownRVPlanetsTargetList import KnownRVPlanetsTargetList
 import numpy as np
@@ -25,6 +24,12 @@ from astropy.time import Time
 from tests.TestSupport.Info import resource_path
 from tests.TestSupport.Utilities import RedirectStreams
 from tests.TestSupport.Utilities import load_vo_csvfile
+
+# Python 3 compatibility:
+if sys.version_info[0] > 2:
+    from io import StringIO
+else:
+    from StringIO import StringIO
 
 # A JSON string containing KnownRVPlanets - from simplest-old.json
 # The part we require is the "modules" dictionary.
@@ -209,7 +214,7 @@ class TestKnownRVPlanetsTargetListMethods(unittest.TestCase):
             # check all the attributes created in the tlist's __init__
             # the "atts_mapping" dictionary maps:
             #    tlist attribute names => votable attribute names
-            for (name_att, name_vo) in tlist.atts_mapping.iteritems():
+            for (name_att, name_vo) in tlist.atts_mapping.items():
                 # the EXOSIMS value: tlist.$name_e[n_host]
                 val_e = getattr(tlist, name_att)[n_host]
                 # the validation value
@@ -250,7 +255,7 @@ class TestKnownRVPlanetsTargetListMethods(unittest.TestCase):
         tlist = self.fixture
         # replace stdout and keep a reference
         original_stdout = sys.stdout
-        sys.stdout = StringIO.StringIO()
+        sys.stdout = StringIO()
         # call __str__ method
         result = tlist.__str__()
         # examine what was printed

--- a/tests/TargetList/test_KnownRVPlanetsTargetList.py
+++ b/tests/TargetList/test_KnownRVPlanetsTargetList.py
@@ -166,7 +166,7 @@ class TestKnownRVPlanetsTargetListMethods(unittest.TestCase):
         self.basic_validation(tlist)
         # ensure the votable-derived star attributes are present
         #   these are set in __init__
-        for att in tlist.atts_mapping.keys():
+        for att in tlist.atts_mapping:
             self.assertIn(att, tlist.__dict__)
             self.assertEqual(len(tlist.__dict__[att]), tlist.nStars)
         # ensure star attributes are present
@@ -284,11 +284,11 @@ class TestKnownRVPlanetsTargetListMethods(unittest.TestCase):
         ensure the TargetList object dictionary is not altered.
         """
         tlist = self.fixture
-        keys = sorted(tlist.__dict__.keys()) # makes a copy
+        keys = sorted(list(tlist.__dict__)) # makes a copy
         tlist.filter_target_list()
         self.assertEqual(tlist._modtype, 'TargetList')
         # just ensure the same keys are still present
-        self.assertListEqual(keys, sorted(tlist.__dict__.keys()))
+        self.assertListEqual(keys, sorted(list(tlist.__dict__)))
 
     
 if __name__ == '__main__':

--- a/tests/TestSupport/Info.py
+++ b/tests/TestSupport/Info.py
@@ -14,6 +14,10 @@ Michael Turmon, JPL, Apr. 2016
 import sys
 import os
 
+# Python 3 compatibility:
+if sys.version_info[0] > 2:
+    basestring = str
+
 
 def resource_path(p = ()):
     r"""Return the path to shared testing resources.  A supplied string or tuple is appended.

--- a/tests/TestSupport/Info.py
+++ b/tests/TestSupport/Info.py
@@ -37,7 +37,7 @@ def resource_path(p = ()):
 
 def main():
     # might as well do something useful
-    print 'resource_path is', resource_path()
+    print('resource_path is', resource_path())
 
 if __name__ == '__main__':
     main()

--- a/tests/ZodiacalLight/test_ZodiacalLight.py
+++ b/tests/ZodiacalLight/test_ZodiacalLight.py
@@ -95,7 +95,7 @@ class TestZodiacalLight(unittest.TestCase):
                     os.remove(self.sim.SurveySimulation.cachefname+'starkfZ')
                 OS = self.sim.OpticalSystem
                 allModes = OS.observingModes
-                mode = filter(lambda mode: mode['detectionMode'] == True, allModes)[0]
+                mode = list(filter(lambda mode: mode['detectionMode'] == True, allModes))[0]
                 hashname = self.sim.SurveySimulation.cachefname
                 self.sim.ZodiacalLight.fZ_startSaved = obj.generate_fZ(self.Obs, self.TL, self.TK, mode, hashname)
                 self.assertEqual(self.sim.ZodiacalLight.fZ_startSaved.shape[0],self.nStars)
@@ -119,7 +119,7 @@ class TestZodiacalLight(unittest.TestCase):
                 currentTimeAbs = self.sim.TimeKeeping.currentTimeAbs
                 OS = self.sim.OpticalSystem
                 allModes = OS.observingModes
-                mode = filter(lambda mode: mode['detectionMode'] == True, allModes)[0]
+                mode = list(filter(lambda mode: mode['detectionMode'] == True, allModes))[0]
                 hashname = self.sim.SurveySimulation.cachefname
                 self.sim.ZodiacalLight.fZ_startSaved = obj.generate_fZ(self.Obs, self.TL, self.TK, mode, hashname)
                 valfZmax = np.zeros(sInds.shape[0])
@@ -143,7 +143,7 @@ class TestZodiacalLight(unittest.TestCase):
                 currentTimeAbs = self.TK.currentTimeAbs
                 OS = self.sim.OpticalSystem
                 allModes = OS.observingModes
-                mode = filter(lambda mode: mode['detectionMode'] == True, allModes)[0]
+                mode = list(filter(lambda mode: mode['detectionMode'] == True, allModes))[0]
                 hashname = self.sim.SurveySimulation.cachefname
                 self.sim.ZodiacalLight.fZ_startSaved = obj.generate_fZ(self.Obs, self.TL, self.TK, mode, hashname)
                 [valfZmin, timefZmin] = obj.calcfZmin(sInds, self.Obs, self.TL, self.TK, mode, hashname)

--- a/tests/ZodiacalLight/test_ZodiacalLight.py
+++ b/tests/ZodiacalLight/test_ZodiacalLight.py
@@ -11,7 +11,12 @@ import numpy as np
 import os, json
 from tests.TestSupport.Utilities import RedirectStreams
 import sys
-import StringIO
+
+# Python 3 compatibility:
+if sys.version_info[0] > 2:
+    from io import StringIO
+else:
+    from StringIO import StringIO
 
 
 """ZodiacalLight module unit tests
@@ -32,7 +37,8 @@ class TestZodiacalLight(unittest.TestCase):
     def setUp(self):
         self.dev_null = open(os.devnull, 'w')
         self.script = resource_path('test-scripts/template_prototype_testing.json')
-        self.spec = json.loads(open(self.script).read())
+        with open(self.script) as f:
+            self.spec = json.loads(f.read())
 
         with RedirectStreams(stdout=self.dev_null):
             self.sim = MissionSim.MissionSim(self.script)
@@ -162,7 +168,7 @@ class TestZodiacalLight(unittest.TestCase):
             with RedirectStreams(stdout=self.dev_null):
                 obj = mod(**self.spec)
             original_stdout = sys.stdout
-            sys.stdout = StringIO.StringIO()
+            sys.stdout = StringIO()
             # call __str__ method
             result = obj.__str__()
             # examine what was printed

--- a/tests/test_MissionSim.py
+++ b/tests/test_MissionSim.py
@@ -11,11 +11,8 @@ r"""MissionSim module unit tests
 Michael Turmon, JPL, Apr. 2016
 """
 
-import sys
 import os
 import json
-import logging
-import StringIO
 import unittest
 from EXOSIMS.MissionSim import MissionSim
 import numpy as np
@@ -112,8 +109,8 @@ class TestMissionSimMethods(unittest.TestCase):
     def test_init_specs(self):
         r"""Test of initialization and __init__ -- specs dictionary.
         """
-        script = open(SimpleScript).read()
-        specs = json.loads(script)
+        with open(SimpleScript) as script:
+            specs = json.loads(script.read())
         self.assertEqual(type(specs), type({}))
         with RedirectStreams(stdout=self.dev_null):
             mission = self.fixture(scriptfile=None, **specs)

--- a/tests/util/test_eccanom.py
+++ b/tests/util/test_eccanom.py
@@ -28,7 +28,7 @@ class TestUtilityMethods(unittest.TestCase):
         # Vallado's m-files.  eccanom() implements the case in the m-file
         # marked "elliptical", because it works for planets in elliptical orbits.
 
-        print 'eccanom()'
+        print('eccanom()')
 
         # precomputed from newtonm.m in Vallado's Matlab source code
         tabulation = {

--- a/tests/util/test_eccanom.py
+++ b/tests/util/test_eccanom.py
@@ -73,7 +73,7 @@ class TestUtilityMethods(unittest.TestCase):
             "rand-20": (0.018781676483, 1.602809881387, 1.621567356335, 1.640316999728),
             }
 
-        for (_, value) in tabulation.iteritems():
+        for (_, value) in tabulation.items():
             (ref_eccentricity, ref_mean_anomaly, ref_ecc_anomaly, _ref_true_anomaly) = value
             exo_ecc_anomaly = eccanom(ref_mean_anomaly, ref_eccentricity)
             # 1: ensure the output agrees with the tabulation


### PR DESCRIPTION
e2eTests.py and unittests pass for Python 2.7 and Python 3.6.

**Note:** pickled files generated by Python 2.7 do not load in Python 3.6 and vice-versa. Make sure to delete all cached files in the .EXOSIMS/cache directory when switching between Python versions.

The following modules were not tested for Python 3.6 compatibility:

- GaiaCat1
- GaiaCatTargetList
- linearJScheduler_DDPC
- linearJScheduler_3DDPC
- SS_char_only2
- tieredScheduler
- tieredScheduler_DD
- util scripts not used in e2eTests.py or unittests

The following modules do not run in either Python 2.7 or Python 3.6:

- SS_char_only
- SS_det_only