### PR TITLE
Remove pow(x,n) from KeplerSTM_C() when n is a small.

### DIFF
--- a/EXOSIMS/util/KeplerSTM_C/CyKeplerSTM.pyx
+++ b/EXOSIMS/util/KeplerSTM_C/CyKeplerSTM.pyx
@@ -2,7 +2,6 @@ import numpy as np
 cimport numpy as np
 DTYPE = np.double
 ctypedef np.double_t DTYPE_t
-from libcpp.vector cimport vector
 
 cdef extern from "KeplerSTM_C.h":
     int KeplerSTM_C(double* x0, double dt, double mu, double* x1, double epsmult)

--- a/EXOSIMS/util/KeplerSTM_C/CyKeplerSTM.pyx
+++ b/EXOSIMS/util/KeplerSTM_C/CyKeplerSTM.pyx
@@ -2,12 +2,14 @@ import numpy as np
 cimport numpy as np
 DTYPE = np.double
 ctypedef np.double_t DTYPE_t
+from libcpp.vector cimport vector
 
 cdef extern from "KeplerSTM_C.h":
     int KeplerSTM_C(double* x0, double dt, double mu, double* x1, double epsmult)
     int KeplerSTM_C_vallado(double* x0, double dt, double mu, double* x1, double epsmult)
 
 cimport cython
+
 @cython.boundscheck(False)
 @cython.wraparound(False)
 def CyKeplerSTM(np.ndarray[DTYPE_t, ndim=1] x0, DTYPE_t dt, np.ndarray[DTYPE_t, ndim=1] mus, DTYPE_t epsmult):

--- a/EXOSIMS/util/KeplerSTM_C/CyKeplerSTM.pyx
+++ b/EXOSIMS/util/KeplerSTM_C/CyKeplerSTM.pyx
@@ -8,7 +8,6 @@ cdef extern from "KeplerSTM_C.h":
     int KeplerSTM_C_vallado(double* x0, double dt, double mu, double* x1, double epsmult)
 
 cimport cython
-
 @cython.boundscheck(False)
 @cython.wraparound(False)
 def CyKeplerSTM(np.ndarray[DTYPE_t, ndim=1] x0, DTYPE_t dt, np.ndarray[DTYPE_t, ndim=1] mus, DTYPE_t epsmult):

--- a/EXOSIMS/util/KeplerSTM_C/CyKeplerSTM_setup.py
+++ b/EXOSIMS/util/KeplerSTM_C/CyKeplerSTM_setup.py
@@ -13,6 +13,9 @@ from Cython.Distutils import build_ext
 ext_modules = [Extension(
     name="CyKeplerSTM",
     sources=["CyKeplerSTM.pyx", "KeplerSTM_C.c"],
+    language="c++",
+    extra_compile_args=["-stdlib=libc++"],
+    extra_link_args= ["-stdlib=libc++"],
     include_dirs = [numpy.get_include()],
     )]
 

--- a/EXOSIMS/util/KeplerSTM_C/KeplerSTM_C.c
+++ b/EXOSIMS/util/KeplerSTM_C/KeplerSTM_C.c
@@ -110,7 +110,7 @@ int KeplerSTM_C (double x0[], double dt, double mu, double x1[], double epsmult)
         U0w2 = 1.0 - 2.0*q;
         U1w2 = 2.0*(1-q)*u;
         const double U1w2_pow5 = U1w2 * U1w2 * U1w2 * U1w2 * U1w2;
-        U = (16.0/15.0)*U1w2*cf + deltaU;
+        U = (16.0/15.0)*U1w2_pow5*cf + deltaU;
         U0 = 2.0*U0w2*U0w2-1.0;
         U1 = 2.0*U0w2*U1w2;
         U2 = 2.0*U1w2*U1w2;

--- a/EXOSIMS/util/KeplerSTM_C/KeplerSTM_C.c
+++ b/EXOSIMS/util/KeplerSTM_C/KeplerSTM_C.c
@@ -50,7 +50,7 @@ int KeplerSTM_C (double x0[], double dt, double mu, double x1[], double epsmult)
     double r0[3] = {x0[0],x0[1],x0[2]};
     double v0[3] = {x0[3],x0[4],x0[5]};
     
-    double r0norm =  sqrt(pow(r0[0], 2)+pow(r0[1], 2)+pow(r0[2], 2));
+    double r0norm =  sqrt(r0[0] * r0[0]+r0[1] * r0[1]+r0[2] * r0[2]);
     double nu0 = DOT(r0,v0,3);
     double beta = 2.0*mu/r0norm - DOT(v0,v0,3);
 
@@ -77,7 +77,7 @@ int KeplerSTM_C (double x0[], double dt, double mu, double x1[], double epsmult)
     double u = 0;
     double q, U0w2, U1w2, U, U0, U1, U2, U3, r, A, B, cf, cfprev;
     while ((fabs(t-dt) > epsmult*tol) && (counter < 1000)){
-        q = beta*pow(u,2.0)/(1+beta*pow(u,2.0));
+        q = beta*u*u/(1+beta*u*u);
         
         /* initialize continued fractions */
         A = 1.0;
@@ -109,10 +109,11 @@ int KeplerSTM_C (double x0[], double dt, double mu, double x1[], double epsmult)
 
         U0w2 = 1.0 - 2.0*q;
         U1w2 = 2.0*(1-q)*u;
-        U = (16.0/15.0)*pow(U1w2,5.0)*cf + deltaU;     
-        U0 = 2.0*pow(U0w2,2.0)-1.0;
+        const double U1w2_pow5 = U1w2 * U1w2 * U1w2 * U1w2 * U1w2;
+        U = (16.0/15.0)*U1w2*cf + deltaU;
+        U0 = 2.0*U0w2*U0w2-1.0;
         U1 = 2.0*U0w2*U1w2;
-        U2 = 2.0*pow(U1w2,2.0);
+        U2 = 2.0*U1w2*U1w2;
         U3 = beta*U + U1*U2/3.0;
         r = r0norm*U0 + nu0*U1 + mu*U2;
         t = r0norm*U1 + nu0*U2 + mu*U3;

--- a/EXOSIMS/util/KeplerSTM_C/KeplerSTM_C.c
+++ b/EXOSIMS/util/KeplerSTM_C/KeplerSTM_C.c
@@ -5,7 +5,7 @@
  * KeplerSTM_C(X0,DT,MU,X1)
  *      X0      6  x 1 : [r_0, v_0]
  *      DT      float  : time step (t1 - t0)
- *      MU      float  : Gravitational paramter
+ *      MU      float  : Gravitational parameter
  *      X1      6 x 1  : [r_1, v_1]
  *      EPSMULT float  : tolerance parameter
  *

--- a/EXOSIMS/util/KeplerSTM_C/KeplerSTM_C.c
+++ b/EXOSIMS/util/KeplerSTM_C/KeplerSTM_C.c
@@ -50,7 +50,7 @@ int KeplerSTM_C (double x0[], double dt, double mu, double x1[], double epsmult)
     double r0[3] = {x0[0],x0[1],x0[2]};
     double v0[3] = {x0[3],x0[4],x0[5]};
     
-    double r0norm =  sqrt(r0[0] * r0[0]+r0[1] * r0[1]+r0[2] * r0[2]);
+    double r0norm =  sqrt(r0[0]*r0[0]+r0[1]*r0[1]+r0[2]*r0[2]);
     double nu0 = DOT(r0,v0,3);
     double beta = 2.0*mu/r0norm - DOT(v0,v0,3);
 

--- a/EXOSIMS/util/KeplerSTM_C/KeplerSTM_C.h
+++ b/EXOSIMS/util/KeplerSTM_C/KeplerSTM_C.h
@@ -5,7 +5,7 @@
  * KeplerSTM_C(X0,DT,MU,X1)
  *      X0      6  x 1 : [r_0, v_0]
  *      DT      float  : time step (t1 - t0)
- *      MU      float  : Gravitational paramter
+ *      MU      float  : Gravitational parameter
  *      X1      6 x 1  : [r_1, v_1]
  *      EPSMULT float  : tolerance parameter
  *


### PR DESCRIPTION
- Fix typos.
- Prepare setup.py to compile C++ code, in accordance with documentation: https://cython.readthedocs.io/en/latest/src/userguide/wrapping_CPlusPlus.html#specify-c-language-in-setup-py
- As discussed in #242 , pow(x,n) hinders performance when n is small and an integer. Initial benchmarks also provided there. Next update will do so for KeplerSTM_C_vallado().