### PR TITLE
Making DulzPlavchanUniverse and KnownRVPlanetsUniverse use phiIndex right

### DIFF
--- a/EXOSIMS/SimulatedUniverse/DulzPlavchanUniverse.py
+++ b/EXOSIMS/SimulatedUniverse/DulzPlavchanUniverse.py
@@ -1,5 +1,6 @@
-from EXOSIMS.Prototypes.SimulatedUniverse import SimulatedUniverse
 import numpy as np
+
+from EXOSIMS.Prototypes.SimulatedUniverse import SimulatedUniverse
 
 
 class DulzPlavchanUniverse(SimulatedUniverse):
@@ -31,6 +32,6 @@ class DulzPlavchanUniverse(SimulatedUniverse):
             self.a *= np.sqrt(TL.L[self.plan2star])
         self.gen_M0()  # initial mean anomaly
         self.Mp = PPop.MfromRp(self.Rp)  # mass
-        self.phiIndex = (
-            None  # Used to switch select specific phase function for each planet
-        )
+        self.phiIndex = np.asarray(
+            []
+        )  # Used to switch select specific phase function for each planet

--- a/EXOSIMS/SimulatedUniverse/KnownRVPlanetsUniverse.py
+++ b/EXOSIMS/SimulatedUniverse/KnownRVPlanetsUniverse.py
@@ -1,7 +1,8 @@
-from EXOSIMS.Prototypes.SimulatedUniverse import SimulatedUniverse
-import numpy as np
 import astropy.units as u
+import numpy as np
 from astropy.time import Time
+
+from EXOSIMS.Prototypes.SimulatedUniverse import SimulatedUniverse
 
 
 class KnownRVPlanetsUniverse(SimulatedUniverse):
@@ -102,6 +103,6 @@ class KnownRVPlanetsUniverse(SimulatedUniverse):
             scale="tai",
         )
         self.M0 = ((missionStart - tper) / T % 1) * 360 * u.deg
-        self.phiIndex = (
-            None  # Used to switch select specific phase function for each planet
-        )
+        self.phiIndex = np.asarray(
+            []
+        )  # Used to switch select specific phase function for each planet


### PR DESCRIPTION
## Describe your changes
Setting SimulatedUniverse.phiIndex to be an empty array instead of None for DulzPlavchanUniverse and KnownRVPlanetsUniverse

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
