### PR TITLE
Making intCutoff_comp use comp_calc instead of comp_per_intTime

### DIFF
--- a/EXOSIMS/Prototypes/TargetList.py
+++ b/EXOSIMS/Prototypes/TargetList.py
@@ -725,14 +725,8 @@ class TargetList(object):
                 self.intCutoff_comp = pickle.load(f)
         else:
             self.vprint("Calculating the integration cutoff time completeness")
-            self.intCutoff_comp = Comp.comp_per_intTime(
-                OS.intCutoff,
-                self,
-                np.arange(self.nStars),
-                ZL.fZ0,
-                ZL.fEZ0,
-                self.int_WA,
-                mode,
+            self.intCutoff_comp = Comp.comp_calc(
+                tmp_smin.to(u.AU).value, tmp_smax.to(u.AU).value, self.intCutoff_dMag
             )
             with open(intCutoff_comp_path, "wb") as f:
                 pickle.dump(self.intCutoff_comp, f)


### PR DESCRIPTION
## Describe your changes
Making intCutoff_comp use comp_calc instead of comp_per_intTime, avoids the repeat computation of intCutoff_dMag.

## Type of change

Please delete options that are not relevant (and this line).

- Bug fix (non-breaking change which fixes an issue)

## Reference any relevant issues (don't forget the #)


## Checklist before requesting a review
- [ x ] I have verified that all unit tests pass in a clean virtual environment and added new unit tests, as needed
- [ ] I have run ``e2eTests`` and added new test scripts, as needed
- [ ] I have verified that all docstrings are properly formatted and added new documentation, as needed
