### PR TITLE
saturation dMag fix for occulters w/o speckle noise

### DIFF
--- a/EXOSIMS/Completeness/GarrettCompleteness.py
+++ b/EXOSIMS/Completeness/GarrettCompleteness.py
@@ -1116,7 +1116,7 @@ class GarrettCompleteness(BrownCompleteness):
                     self.f_dmagv,
                     d1,
                     max_dMag[i],
-                    args=(smin[i], smax[i]),
+                    args=(smin[i], min(smax[i], np.finfo(np.float32).max)),
                     n=self.order_of_quadrature,
                 )[0]
 

--- a/EXOSIMS/Prototypes/TargetList.py
+++ b/EXOSIMS/Prototypes/TargetList.py
@@ -1879,10 +1879,12 @@ class TargetList(object):
             fEZ = np.repeat(ZL.fEZ0, len(sInds))
 
             saturation_dMag = np.zeros(len(sInds))
-            if mode['syst'].get('occulter'):
+            if mode["syst"].get("occulter"):
                 saturation_dMag = np.full(shape=len(sInds), fill_value=np.inf)
             else:
-                for i, sInd in enumerate(tqdm(sInds, desc="Calculating saturation_dMag")):
+                for i, sInd in enumerate(
+                    tqdm(sInds, desc="Calculating saturation_dMag")
+                ):
                     args = (
                         self,
                         [sInd],
@@ -1893,7 +1895,10 @@ class TargetList(object):
                         None,
                     )
                     singularity_res = root_scalar(
-                        OS.int_time_denom_obj, args=args, method="brentq", bracket=[10, 40]
+                        OS.int_time_denom_obj,
+                        args=args,
+                        method="brentq",
+                        bracket=[10, 40],
                     )
                     singularity_dMag = singularity_res.root
                     saturation_dMag[i] = singularity_dMag

--- a/EXOSIMS/Prototypes/TargetList.py
+++ b/EXOSIMS/Prototypes/TargetList.py
@@ -1879,21 +1879,24 @@ class TargetList(object):
             fEZ = np.repeat(ZL.fEZ0, len(sInds))
 
             saturation_dMag = np.zeros(len(sInds))
-            for i, sInd in enumerate(tqdm(sInds, desc="Calculating saturation_dMag")):
-                args = (
-                    self,
-                    [sInd],
-                    [fZ[i].value] * fZ.unit,
-                    [fEZ[i].value] * fEZ.unit,
-                    [self.int_WA[i].value] * self.int_WA.unit,
-                    mode,
-                    None,
-                )
-                singularity_res = root_scalar(
-                    OS.int_time_denom_obj, args=args, method="brentq", bracket=[10, 40]
-                )
-                singularity_dMag = singularity_res.root
-                saturation_dMag[i] = singularity_dMag
+            if mode['syst'].get('occulter'):
+                saturation_dMag = np.full(shape=len(sInds), fill_value=np.inf)
+            else:
+                for i, sInd in enumerate(tqdm(sInds, desc="Calculating saturation_dMag")):
+                    args = (
+                        self,
+                        [sInd],
+                        [fZ[i].value] * fZ.unit,
+                        [fEZ[i].value] * fEZ.unit,
+                        [self.int_WA[i].value] * self.int_WA.unit,
+                        mode,
+                        None,
+                    )
+                    singularity_res = root_scalar(
+                        OS.int_time_denom_obj, args=args, method="brentq", bracket=[10, 40]
+                    )
+                    singularity_dMag = singularity_res.root
+                    saturation_dMag[i] = singularity_dMag
 
             # This block is not relevant w/ current implementation, but this
             # will create an interpolant of the saturation dMag as a function


### PR DESCRIPTION
## Describe your changes
In the TargetList prototype the calc_saturation_dMag function always assumed that the denominator of the integration time used the model from Nemati. But the calc_intTime function treats occulters differently and assumes no speckle noise. That same condition was added to the calc_saturation_dMag function so that the values returned are infinite instead of assuming speckle noise.

In GarrettCompleteness there was an error in the handling of infinite smax values which occur for occulters. Added a check that changes infinite smax values to the max float value.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Reference any relevant issues (don't forget the #)
N/A

## Checklist before requesting a review
- [x] I have verified that all unit tests pass in a clean virtual environment and added new unit tests, as needed
- [x] I have run ``e2eTests`` and added new test scripts, as needed
- [x] I have verified that all docstrings are properly formatted and added new documentation, as needed
