### PR TITLE
Fixing HIPfromSimbad coordinates.

### DIFF
--- a/EXOSIMS/StarCatalog/HIPfromSimbad.py
+++ b/EXOSIMS/StarCatalog/HIPfromSimbad.py
@@ -102,8 +102,8 @@ class HIPfromSimbad(StarCatalog):
         self.coords = SkyCoord(
             ra=simbad_list["RA"].data.data,
             dec=simbad_list["DEC"].data.data,
-            # distance=self.dist,
-            unit=(u.hourangle, u.deg, u.arcsec),
+            distance=self.dist,
+            unit=(u.hourangle, u.deg, u.pc),
         )
         # Right Ascension of the planetary system in decimal degrees
         # Declination of the planetary system in decimal degrees


### PR DESCRIPTION
The distance was commented out, presumably due to the SkyCoord call associating distance with arcseconds instead of parsecs for some reason.

## Describe your changes
Fixing bug in HIPfromSimbad that was caused by the distance line being commented out.

## Type of change

Please delete options that are not relevant (and this line).

- Bug fix (non-breaking change which fixes an issue)

## Reference any relevant issues (don't forget the #)


## Checklist before requesting a review
- [x] I have verified that all unit tests pass in a clean virtual environment and added new unit tests, as needed
- [x] I have run ``e2eTests`` and added new test scripts, as needed
- [x] I have verified that all docstrings are properly formatted and added new documentation, as needed
