### PR TITLE
fixing intermittent error caused by attempting to index koMap beyond …

### DIFF
--- a/EXOSIMS/Prototypes/SurveySimulation.py
+++ b/EXOSIMS/Prototypes/SurveySimulation.py
@@ -2013,6 +2013,11 @@ class SurveySimulation(object):
             startTime = (
                 TK.currentTimeAbs.copy() + mode["syst"]["ohTime"] + Obs.settlingTime
             )
+
+            # if we're beyond mission end, bail out
+            if startTime >= TK.missionFinishAbs:
+                return characterized, fZ, systemParams, SNR, intTime
+
             startTimeNorm = (
                 TK.currentTimeNorm.copy() + mode["syst"]["ohTime"] + Obs.settlingTime
             )


### PR DESCRIPTION
…the end of the mission (occurs very infrequently when a characterization is attempted with less time left than the overhead/settling time).

- Bug fix (non-breaking change which fixes an issue)
