### PR TITLE
fix: svn shell-out stderr is captured

### DIFF
--- a/EXOSIMS/Prototypes/SurveySimulation.py
+++ b/EXOSIMS/Prototypes/SurveySimulation.py
@@ -2499,6 +2499,7 @@ class SurveySimulation(object):
             rev = subprocess.Popen(
                 "svn info " + path + "| grep \"Revision\" | awk '{print $2}'",
                 stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
                 shell=True,
             )
             (svnRev, err) = rev.communicate()


### PR DESCRIPTION
## Describe your changes
stderr is now captured when SurveySimulation is checking for svn version, eliminating chatter to stderr on object initialization.
Objective is to clean up console interaction  before workshop.

## Type of change
- Bug fix

## Reference any relevant issues (don't forget the #)


## Checklist before requesting a review
- [NA?] I have verified that all unit tests pass in a clean virtual environment and added new unit tests, as needed
- [ x] I have run ``e2eTests`` and added new test scripts, as needed
- [N/A] I have verified that all docstrings are properly formatted and added new documentation, as needed
