### PR TITLE
Common system plane with systemOmega and calc_dMag_per_intTime bug fix

### DIFF
--- a/EXOSIMS/OpticalSystem/Nemati.py
+++ b/EXOSIMS/OpticalSystem/Nemati.py
@@ -327,9 +327,15 @@ class Nemati(OpticalSystem):
             # This tests whether an integration time corresponding to an
             # unrealistically dim planet can be calculated. If not then the
             # dMag/intTime curve has a singularity and we have to accomodate that
-            has_singularity = np.isnan(
-                self.calc_intTime(TL, _sInds, _fZ, _fEZ, np.array([40]), _WA, mode)
-            )
+            lb = self.int_time_denom_obj(10, *args_denom)
+            ub = self.int_time_denom_obj(40, *args_denom)
+            if np.sign(lb) == np.sign(ub):
+                has_singularity = False
+            else:
+                has_singularity = True
+            # has_singularity = np.isnan(
+            #     self.calc_intTime(TL, _sInds, _fZ, _fEZ, np.array([40]), _WA, mode)
+            # )
             if has_singularity:
                 # minimize_scalar sets it's initial position in the middle of
                 # the bounds, but if the middle of the bounds is in the regime
@@ -350,11 +356,11 @@ class Nemati(OpticalSystem):
                     # Adjust the lower bounds until we have proper convergence
                     star_vmag = TL.Vmag[sInds[i]]
                     test_lb_subractions = [2, 10]
+                    converged = False
                     for j, lb_subtraction in enumerate(test_lb_subractions):
                         initial_lower_bound = max(
                             5, singularity_dMag - lb_subtraction - star_vmag
                         )
-                        converged = False
                         lb_adjustment = 0
                         while not converged:
                             dMag_lb = initial_lower_bound + lb_adjustment

--- a/EXOSIMS/Prototypes/PlanetPopulation.py
+++ b/EXOSIMS/Prototypes/PlanetPopulation.py
@@ -267,9 +267,7 @@ class PlanetPopulation(object):
 
         return Mp
 
-    def gen_angles(
-        self, n, commonSystemInclinations=False, commonSystemInclinationParams=None
-    ):
+    def gen_angles(self, n, commonSystemPlane=False, commonSystemPlaneParams=None):
         """Generate inclination, longitude of the ascending node, and argument
         of periapse in degrees
 
@@ -280,14 +278,16 @@ class PlanetPopulation(object):
         Args:
             n (int):
                 Number of samples to generate
-            commonSystemInclinations (bool):
+            commonSystemPlane (bool):
                 Generate delta inclinations from common orbital plane rather than
-                fully independent inclinations.  Defaults False.  If True,
-                commonSystemInclinationParams must be supplied.
-            commonSystemInclinationParams (None or list):
-                2 element list of [mean, standard deviation] in units of degrees,
-                describing the distribution of inclinations relative to a common orbital
-                plane.  Ignored if commonSystemInclinations is False.
+                fully independent inclinations and Omegas.  Defaults False.  If True,
+                commonSystemPlaneParams must be supplied.
+            commonSystemPlaneParams (None or list):
+                4 element list of [I mean, I standard deviation,
+                                   O mean, O standard deviation]
+                in units of degrees, describing the distribution of
+                inclinations and Omegas relative to a common orbital plane.
+                Ignored if commonSystemPlane is False.
 
         Returns:
             tuple:
@@ -302,22 +302,22 @@ class PlanetPopulation(object):
         n = self.gen_input_check(n)
         # inclination
         C = 0.5 * (np.cos(self.Irange[0]) - np.cos(self.Irange[1]))
-        if commonSystemInclinations:
+        if commonSystemPlane:
             assert (
-                len(commonSystemInclinationParams) == 2
-            ), "commonSystemInclinationParams must be a two-element list"
+                len(commonSystemPlaneParams) == 4
+            ), "commonSystemPlaneParams must be a four-element list"
             I = (  # noqa: 741
                 np.random.normal(
-                    loc=commonSystemInclinationParams[0],
-                    scale=commonSystemInclinationParams[1],
+                    loc=commonSystemPlaneParams[0],
+                    scale=commonSystemPlaneParams[1],
                     size=n,
                 )
                 * u.deg
             )
             O = (
                 np.random.normal(
-                    loc=commonSystemInclinationParams[0],
-                    scale=commonSystemInclinationParams[1],
+                    loc=commonSystemPlaneParams[2],
+                    scale=commonSystemPlaneParams[3],
                     size=n,
                 )
                 * u.deg

--- a/EXOSIMS/Prototypes/PlanetPopulation.py
+++ b/EXOSIMS/Prototypes/PlanetPopulation.py
@@ -1,11 +1,13 @@
-from EXOSIMS.util.vprint import vprint
-from EXOSIMS.util.get_module import get_module
-from EXOSIMS.util.get_dirs import get_cache_dir
-from EXOSIMS.util.keyword_fun import get_all_args
-import astropy.units as u
-import numpy as np
 import copy
 import numbers
+
+import astropy.units as u
+import numpy as np
+
+from EXOSIMS.util.get_dirs import get_cache_dir
+from EXOSIMS.util.get_module import get_module
+from EXOSIMS.util.keyword_fun import get_all_args
+from EXOSIMS.util.vprint import vprint
 
 
 class PlanetPopulation(object):
@@ -312,14 +314,22 @@ class PlanetPopulation(object):
                 )
                 * u.deg
             )
+            O = (
+                np.random.normal(
+                    loc=commonSystemInclinationParams[0],
+                    scale=commonSystemInclinationParams[1],
+                    size=n,
+                )
+                * u.deg
+            )
         else:
             I = (  # noqa: 741
                 np.arccos(np.cos(self.Irange[0]) - 2.0 * C * np.random.uniform(size=n))
             ).to("deg")
+            # longitude of the ascending node
+            Or = self.Orange.to("deg").value
+            O = np.random.uniform(low=Or[0], high=Or[1], size=n) * u.deg  # noqa: 741
 
-        # longitude of the ascending node
-        Or = self.Orange.to("deg").value
-        O = np.random.uniform(low=Or[0], high=Or[1], size=n) * u.deg  # noqa: 741
         # argument of periapse
         wr = self.wrange.to("deg").value
         w = np.random.uniform(low=wr[0], high=wr[1], size=n) * u.deg

--- a/EXOSIMS/Prototypes/SimulatedUniverse.py
+++ b/EXOSIMS/Prototypes/SimulatedUniverse.py
@@ -26,15 +26,16 @@ class SimulatedUniverse(object):
         lucky_planets (bool):
             Used downstream in survey simulation. If True, planets are
             observed at optimal times. Defaults to False
-        commonSystemInclinations (bool):
+        commonSystemPlane (bool):
             Planet inclinations are sampled as normally distributed about a
             common system plane. Defaults to False
-        commonSystemInclinationParams (list(float)):
-            [Mean, Standard Deviation] defining the normal distribution of
-            inclinations about a common system plane.  Ignored if
-            commonSystemInclinations is False. Defaults to [0 2.25], where the
-            standard deviation is approximately the standard deviation of
-            solar system planet inclinations.
+        commonSystemPlaneParams (list(float)):
+            [inclination mean, inclination standard deviation, Omega mean,
+             Omega standard deviation] defining the normal distribution of
+            inclinations and longitudes of the ascending node about a common
+            system plane.  Ignored if commonSystemPlane is False. Defaults to
+            [0 2.25, 0, 2.25], where the standard deviation is approximately
+            the standard deviation of solar system planet inclinations.
         **specs:
             :ref:`sec:inputspec`
 
@@ -48,15 +49,15 @@ class SimulatedUniverse(object):
             BackgroundSources object
         cachedir (str):
             Path to the EXOSIMS cache directory (see :ref:`EXOSIMSCACHE`)
-        commonSystemInclinationParams (list):
+        commonSystemPlaneParams (list):
             2 element list of [mean, standard deviation] in units of degrees,
             describing the distribution of inclinations relative to a common orbital
-            plane.  Ignored if commonSystemInclinations is False.
-        commonSystemInclinations (bool):
+            plane.  Ignored if commonSystemPlane is False.
+        commonSystemPlane (bool):
             If False, planet inclinations are independently drawn for all planets,
             including those in the same target system.  If True, inclinations will be
             drawn from a normal distribution defined by
-            commonSystemInclinationParams and added to a single inclination value drawn
+            commonSystemPlaneParams and added to a single inclination value drawn
             for each system.
         Completeness (:ref:`Completeness`):
             Completeness object
@@ -153,8 +154,8 @@ class SimulatedUniverse(object):
         Min=None,
         cachedir=None,
         lucky_planets=False,
-        commonSystemInclinations=False,
-        commonSystemInclinationParams=[0, 2.25],
+        commonSystemPlane=False,
+        commonSystemPlaneParams=[0, 2.25, 0, 2.25],
         **specs
     ):
 
@@ -165,13 +166,13 @@ class SimulatedUniverse(object):
         self.vprint = vprint(specs.get("verbose", True))
         self.lucky_planets = lucky_planets
         self._outspec["lucky_planets"] = lucky_planets
-        self.commonSystemInclinations = bool(commonSystemInclinations)
-        self._outspec["commonSystemInclinations"] = commonSystemInclinations
+        self.commonSystemPlane = bool(commonSystemPlane)
+        self._outspec["commonSystemPlane"] = commonSystemPlane
         assert (
-            len(commonSystemInclinationParams) == 2
-        ), "commonSystemInclinationParams must be a two-element list"
-        self.commonSystemInclinationParams = commonSystemInclinationParams
-        self._outspec["commonSystemInclinationParams"] = commonSystemInclinationParams
+            len(commonSystemPlaneParams) == 4
+        ), "commonSystemPlaneParams must be a four-element list"
+        self.commonSystemPlaneParams = commonSystemPlaneParams
+        self._outspec["commonSystemPlaneParams"] = commonSystemPlaneParams
 
         # save fixed number of planets to generate
         self.fixedPlanPerStar = fixedPlanPerStar
@@ -339,8 +340,8 @@ class SimulatedUniverse(object):
             # sample all of the orbital and physical parameters
             self.I, self.O, self.w = PPop.gen_angles(
                 self.nPlans,
-                commonSystemInclinations=self.commonSystemInclinations,
-                commonSystemInclinationParams=self.commonSystemInclinationParams,
+                commonSystemPlane=self.commonSystemPlane,
+                commonSystemPlaneParams=self.commonSystemPlaneParams,
             )
             self.setup_system_planes()
 
@@ -663,9 +664,9 @@ class SimulatedUniverse(object):
             "plan2star": self.plan2star,
             "star": self.TargetList.Name[self.plan2star],
         }
-        if self.commonSystemInclinations:
-            systems["starI"] = self.TargetList.I
-            systems["starPA"] = self.TargetList.PA
+        if self.commonSystemPlane:
+            systems["systemInclination"] = self.TargetList.systemInclination
+            systems["systemOmega"] = self.TargetList.systemOmega
         if self.ZodiacalLight.commonSystemfEZ:
             systems["starnEZ"] = self.ZodiacalLight.nEZ
 
@@ -684,10 +685,10 @@ class SimulatedUniverse(object):
 
         .. note::
 
-            If keyword ``starI`` is present in the dictionary, it is assumed that it was
-            generated with ``commonSystemInclinations`` set to True.  Similarly, if
-            keyword ``starnEZ`` is present, it is assumed that
-            ``ZodiacalLight.commonSystemfEZ`` should be true.
+            If keyword ``systemInclination`` is present in the dictionary, it
+            is assumed that it was generated with ``commonSystemPlane`` set to
+            True.  Similarly, if keyword ``starnEZ`` is present, it is assumed
+            that ``ZodiacalLight.commonSystemfEZ`` should be true.
 
         .. warning::
 
@@ -707,11 +708,15 @@ class SimulatedUniverse(object):
         self.p = systems["p"]
         self.plan2star = systems["plan2star"]
 
-        if "starI" in systems:
-            self.TargetList.I = systems["starI"]  # noqa: E741
-            self.commonSystemInclinations = True
-        if "starPA" in systems:
-            self.TargetList.PA = systems["starPA"]
+        if "systemInclination" in systems:
+            self.TargetList.systemInclination = systems[
+                "systemInclination"
+            ]  # noqa: E741
+            self.commonSystemPlane = True
+            if "systemOmega" in systems:
+                # leaving as if for backwards compatibility with old dumped
+                # params for now
+                self.TargetList.systemOmega = systems["systemOmega"]
 
         if "starnEZ" in systems:
             self.ZodiacalLight.nEZ = systems["starnEZ"]
@@ -803,7 +808,7 @@ class SimulatedUniverse(object):
     def setup_system_planes(self):
         """
         Helper function that augments the system planes if
-        commonSystemInclinations is true
+        commonSystemPlane is true
 
         Args:
             None
@@ -811,11 +816,11 @@ class SimulatedUniverse(object):
         Returns:
             None
         """
-        if self.commonSystemInclinations:
-            self.I += self.TargetList.I[self.plan2star]
+        if self.commonSystemPlane:
+            self.I += self.TargetList.systemInclination[self.plan2star]
             # Ensure all inclinations are in [0, pi]
             self.I = (self.I.to(u.deg).value % 180) * u.deg
 
-            self.O += self.TargetList.PA[self.plan2star]
+            self.O += self.TargetList.systemOmega[self.plan2star]
             # Cut longitude of the ascending nodes to [0, 2pi]
             self.O = (self.O.to(u.deg).value % 360) * u.deg

--- a/EXOSIMS/Prototypes/TargetList.py
+++ b/EXOSIMS/Prototypes/TargetList.py
@@ -161,7 +161,7 @@ class TargetList(object):
             if attribute ``getKnownPlanets`` is True. Otherwise all entries are False.
         Hmag (numpy.ndarray):
             H band magnitudes
-        I (astropy.units.quantity.Quantity):
+        systemInclination (astropy.units.quantity.Quantity):
             Inclinations of target system orbital planes
         Imag (numpy.ndarray):
             I band magnitudes
@@ -204,10 +204,10 @@ class TargetList(object):
             Target names (str array)
         nStars (int):
             Number of stars currently in target list
+        systemOmega (astropy.units.quantity.Quantity):
+            Base longitude of the ascending node for target system orbital planes
         OpticalSystem (:ref:`OpticalSystem`):
             :ref:`OpticalSystem` object
-        PA (astropy.units.quantity.Quantity):
-            Position angles of target system orbital planes
         parx (astropy.units.quantity.Quantity):
             Parallaxes
         PlanetPhysicalModel (:ref:`PlanetPhysicalModel`):
@@ -452,10 +452,10 @@ class TargetList(object):
         self.stellar_mass()
         self.stellar_diameter()
         # Calculate Star System Inclinations
-        self.I = self.gen_inclinations(self.PlanetPopulation.Irange)
+        self.systemInclination = self.gen_inclinations(self.PlanetPopulation.Irange)
 
-        # Calculate Star System position angles
-        self.PA = self.gen_position_angles(self.PlanetPopulation.Orange)
+        # Calculate common Star System longitude of the ascending node
+        self.systemOmega = self.gen_Omegas(self.PlanetPopulation.Orange)
 
         # create placeholder array black-body spectra
         # (only filled if any modes require it)
@@ -1750,16 +1750,17 @@ class TargetList(object):
             np.arccos(np.cos(Irange[0]) - 2.0 * C * np.random.uniform(size=self.nStars))
         ).to("deg")
 
-    def gen_position_angles(self, Orange):
-        """Randomly Generate Position Angle of Target System Orbital Plane
+    def gen_Omegas(self, Orange):
+        """Randomly Generate longitude of the ascending node for target system
+        orbital planes
 
         Args:
             Orange (~numpy.ndarray(float)):
-                The range to generate position angles over
+                The range to generate Omegas over
 
         Returns:
             ~astropy.units.Quantity(~numpy.ndarray(float)):
-                System position angles
+                System Omegas
         """
         return (
             np.random.uniform(

--- a/EXOSIMS/SimulatedUniverse/DulzPlavchanUniverse.py
+++ b/EXOSIMS/SimulatedUniverse/DulzPlavchanUniverse.py
@@ -26,7 +26,13 @@ class DulzPlavchanUniverse(SimulatedUniverse):
         self.nPlans = len(self.plan2star)
 
         # sample all of the orbital and physical parameters
-        self.I, self.O, self.w = PPop.gen_angles(self.nPlans)
+        self.I, self.O, self.w = PPop.gen_angles(
+            self.nPlans,
+            commonSystemInclinations=self.commonSystemInclinations,
+            commonSystemInclinationParams=self.commonSystemInclinationParams,
+        )
+        self.setup_system_planes()
+
         self.a, self.e, self.p, self.Rp = PPop.gen_plan_params(self.nPlans)
         if PPop.scaleOrbits:
             self.a *= np.sqrt(TL.L[self.plan2star])

--- a/EXOSIMS/SimulatedUniverse/DulzPlavchanUniverse.py
+++ b/EXOSIMS/SimulatedUniverse/DulzPlavchanUniverse.py
@@ -28,8 +28,8 @@ class DulzPlavchanUniverse(SimulatedUniverse):
         # sample all of the orbital and physical parameters
         self.I, self.O, self.w = PPop.gen_angles(
             self.nPlans,
-            commonSystemInclinations=self.commonSystemInclinations,
-            commonSystemInclinationParams=self.commonSystemInclinationParams,
+            commonSystemPlane=self.commonSystemPlane,
+            commonSystemPlaneParams=self.commonSystemPlaneParams,
         )
         self.setup_system_planes()
 

--- a/EXOSIMS/SimulatedUniverse/DulzPlavchanUniverseEarthsOnly.py
+++ b/EXOSIMS/SimulatedUniverse/DulzPlavchanUniverseEarthsOnly.py
@@ -56,8 +56,8 @@ class DulzPlavchanUniverseEarthsOnly(SimulatedUniverse):
         # sample all of the orbital and physical parameters
         self.I, self.O, self.w = PPop.gen_angles(
             self.nPlans,
-            commonSystemInclinations=self.commonSystemInclinations,
-            commonSystemInclinationParams=self.commonSystemInclinationParams,
+            commonSystemPlane=self.commonSystemPlane,
+            commonSystemPlaneParams=self.commonSystemPlaneParams,
         )
         self.setup_system_planes()
 

--- a/EXOSIMS/SimulatedUniverse/DulzPlavchanUniverseEarthsOnly.py
+++ b/EXOSIMS/SimulatedUniverse/DulzPlavchanUniverseEarthsOnly.py
@@ -1,6 +1,7 @@
-from EXOSIMS.Prototypes.SimulatedUniverse import SimulatedUniverse
-import numpy as np
 import astropy.units as u
+import numpy as np
+
+from EXOSIMS.Prototypes.SimulatedUniverse import SimulatedUniverse
 
 
 class DulzPlavchanUniverseEarthsOnly(SimulatedUniverse):
@@ -53,7 +54,13 @@ class DulzPlavchanUniverseEarthsOnly(SimulatedUniverse):
             self.a *= np.sqrt(TL.L[self.plan2star])
 
         # sample all of the orbital and physical parameters
-        self.I, self.O, self.w = PPop.gen_angles(self.nPlans)
+        self.I, self.O, self.w = PPop.gen_angles(
+            self.nPlans,
+            commonSystemInclinations=self.commonSystemInclinations,
+            commonSystemInclinationParams=self.commonSystemInclinationParams,
+        )
+        self.setup_system_planes()
+
         self.gen_M0()  # initial mean anomaly
         self.Mp = PPop.MfromRp(self.Rp)  # mass
 

--- a/EXOSIMS/SimulatedUniverse/KeplerLikeUniverse.py
+++ b/EXOSIMS/SimulatedUniverse/KeplerLikeUniverse.py
@@ -47,8 +47,8 @@ class KeplerLikeUniverse(SimulatedUniverse):
         self.a, self.e, self.p, _ = PPop.gen_plan_params(self.nPlans)
         self.I, self.O, self.w = PPop.gen_angles(
             self.nPlans,
-            commonSystemInclinations=self.commonSystemInclinations,
-            commonSystemInclinationParams=self.commonSystemInclinationParams,
+            commonSystemPlane=self.commonSystemPlane,
+            commonSystemPlaneParams=self.commonSystemPlaneParams,
         )
         self.setup_system_planes()
 

--- a/EXOSIMS/SimulatedUniverse/KeplerLikeUniverse.py
+++ b/EXOSIMS/SimulatedUniverse/KeplerLikeUniverse.py
@@ -1,6 +1,7 @@
-from EXOSIMS.Prototypes.SimulatedUniverse import SimulatedUniverse
-import numpy as np
 import astropy.units as u
+import numpy as np
+
+from EXOSIMS.Prototypes.SimulatedUniverse import SimulatedUniverse
 
 
 class KeplerLikeUniverse(SimulatedUniverse):
@@ -44,7 +45,13 @@ class KeplerLikeUniverse(SimulatedUniverse):
         self.sInds = np.unique(self.plan2star)
 
         self.a, self.e, self.p, _ = PPop.gen_plan_params(self.nPlans)
-        self.I, self.O, self.w = PPop.gen_angles(self.nPlans)
+        self.I, self.O, self.w = PPop.gen_angles(
+            self.nPlans,
+            commonSystemInclinations=self.commonSystemInclinations,
+            commonSystemInclinationParams=self.commonSystemInclinationParams,
+        )
+        self.setup_system_planes()
+
         # inflated planets have to be moved to tidally locked orbits
         self.a[self.Rp > np.nanmax(PPMod.ggdat["radii"])] = 0.02 * u.AU
         if PPop.scaleOrbits:

--- a/EXOSIMS/SimulatedUniverse/KnownRVPlanetsUniverse.py
+++ b/EXOSIMS/SimulatedUniverse/KnownRVPlanetsUniverse.py
@@ -62,7 +62,11 @@ class KnownRVPlanetsUniverse(SimulatedUniverse):
         )  # eccentricity
         self.e[self.e < 0.0] = 0.0
         self.e[self.e > 0.9] = 0.9
-        Itmp, Otmp, self.w = PPop.gen_angles(self.nPlans)
+        Itmp, Otmp, self.w = PPop.gen_angles(
+            self.nPlans,
+            commonSystemInclinations=self.commonSystemInclinations,
+            commonSystemInclinationParams=self.commonSystemInclinationParams,
+        )
         self.I = (
             PPop.allplanetdata["pl_orbincl"][planinds]
             + np.random.normal(size=self.nPlans)
@@ -78,6 +82,7 @@ class KnownRVPlanetsUniverse(SimulatedUniverse):
         )
         self.O = lper.data * u.deg - self.w  # longitude of ascending node
         self.O[np.isnan(self.O)] = Otmp[np.isnan(self.O)]
+        self.setup_system_planes()
         self.p = PPMod.calc_albedo_from_sma(self.a, PPop.prange)  # albedo
         self.Mp = PPop.mass[planinds]  # mass first!
         self.Rp = PPMod.calc_radius_from_mass(self.Mp)  # radius from mass

--- a/EXOSIMS/SimulatedUniverse/KnownRVPlanetsUniverse.py
+++ b/EXOSIMS/SimulatedUniverse/KnownRVPlanetsUniverse.py
@@ -62,11 +62,7 @@ class KnownRVPlanetsUniverse(SimulatedUniverse):
         )  # eccentricity
         self.e[self.e < 0.0] = 0.0
         self.e[self.e > 0.9] = 0.9
-        Itmp, Otmp, self.w = PPop.gen_angles(
-            self.nPlans,
-            commonSystemInclinations=self.commonSystemInclinations,
-            commonSystemInclinationParams=self.commonSystemInclinationParams,
-        )
+        Itmp, Otmp, self.w = PPop.gen_angles(self.nPlans)
         self.I = (
             PPop.allplanetdata["pl_orbincl"][planinds]
             + np.random.normal(size=self.nPlans)
@@ -82,7 +78,6 @@ class KnownRVPlanetsUniverse(SimulatedUniverse):
         )
         self.O = lper.data * u.deg - self.w  # longitude of ascending node
         self.O[np.isnan(self.O)] = Otmp[np.isnan(self.O)]
-        self.setup_system_planes()
         self.p = PPMod.calc_albedo_from_sma(self.a, PPop.prange)  # albedo
         self.Mp = PPop.mass[planinds]  # mass first!
         self.Rp = PPMod.calc_radius_from_mass(self.Mp)  # radius from mass

--- a/EXOSIMS/SimulatedUniverse/SAG13Universe.py
+++ b/EXOSIMS/SimulatedUniverse/SAG13Universe.py
@@ -1,5 +1,6 @@
-from EXOSIMS.Prototypes.SimulatedUniverse import SimulatedUniverse
 import numpy as np
+
+from EXOSIMS.Prototypes.SimulatedUniverse import SimulatedUniverse
 
 
 class SAG13Universe(SimulatedUniverse):
@@ -39,7 +40,12 @@ class SAG13Universe(SimulatedUniverse):
         self.nPlans = len(self.plan2star)
 
         # sample all of the orbital and physical parameters
-        self.I, self.O, self.w = PPop.gen_angles(self.nPlans)
+        self.I, self.O, self.w = PPop.gen_angles(
+            self.nPlans,
+            commonSystemInclinations=self.commonSystemInclinations,
+            commonSystemInclinationParams=self.commonSystemInclinationParams,
+        )
+        self.setup_system_planes()
         self.a, self.e, self.p, self.Rp = PPop.gen_plan_params(self.nPlans)
         if PPop.scaleOrbits:
             self.a *= np.sqrt(TL.L[self.plan2star])

--- a/EXOSIMS/SimulatedUniverse/SAG13Universe.py
+++ b/EXOSIMS/SimulatedUniverse/SAG13Universe.py
@@ -42,8 +42,8 @@ class SAG13Universe(SimulatedUniverse):
         # sample all of the orbital and physical parameters
         self.I, self.O, self.w = PPop.gen_angles(
             self.nPlans,
-            commonSystemInclinations=self.commonSystemInclinations,
-            commonSystemInclinationParams=self.commonSystemInclinationParams,
+            commonSystemPlane=self.commonSystemPlane,
+            commonSystemPlaneParams=self.commonSystemPlaneParams,
         )
         self.setup_system_planes()
         self.a, self.e, self.p, self.Rp = PPop.gen_plan_params(self.nPlans)

--- a/EXOSIMS/SimulatedUniverse/SolarSystemUniverse.py
+++ b/EXOSIMS/SimulatedUniverse/SolarSystemUniverse.py
@@ -1,6 +1,7 @@
-from EXOSIMS.Prototypes.SimulatedUniverse import SimulatedUniverse
-import numpy as np
 import astropy.units as u
+import numpy as np
+
+from EXOSIMS.Prototypes.SimulatedUniverse import SimulatedUniverse
 
 
 class SolarSystemUniverse(SimulatedUniverse):
@@ -32,9 +33,7 @@ class SolarSystemUniverse(SimulatedUniverse):
             commonSystemInclinations=self.commonSystemInclinations,
             commonSystemInclinationParams=self.commonSystemInclinationParams,
         )
-
-        if self.commonSystemInclinations:  # OVERWRITE I with TL.I+dI
-            self.I += TL.I[self.plan2star]
+        self.setup_system_planes()
 
         self.a, self.e, self.p, self.Rp = PPop.gen_plan_params(self.nPlans)
 

--- a/EXOSIMS/SimulatedUniverse/SolarSystemUniverse.py
+++ b/EXOSIMS/SimulatedUniverse/SolarSystemUniverse.py
@@ -30,8 +30,8 @@ class SolarSystemUniverse(SimulatedUniverse):
         # sample all of the orbital and physical parameters
         self.I, self.O, self.w = PPop.gen_angles(
             self.nPlans,
-            commonSystemInclinations=self.commonSystemInclinations,
-            commonSystemInclinationParams=self.commonSystemInclinationParams,
+            commonSystemPlane=self.commonSystemPlane,
+            commonSystemPlaneParams=self.commonSystemPlaneParams,
         )
         self.setup_system_planes()
 


### PR DESCRIPTION
## Describe your changes
Turned the commonSystemInclination system into a commonSystemPlane system, where the TargetList generates both a systemInclination and systemOmega then offsets the planets based on commonSystemPlaneParams. Changed the TL attribute "I" to "systemInclination" to avoid confusion with the SimulatedUniverse "I" attribute for the planet inclinations. Small performance improvement by moving the "converged" Boolean in Nemati's calc_dMag_per_intTime function out of the lower bound loop to avoid always running the minimization twice.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist before requesting a review
- [ x ] I have verified that all unit tests pass in a clean virtual environment and added new unit tests, as needed
- [ x ] I have run ``e2eTests`` and added new test scripts, as needed
- [ x ] I have verified that all docstrings are properly formatted and added new documentation, as needed
