### PR TITLE
adding cherryPickStars and skipSaturationCalcs

### DIFF
--- a/EXOSIMS/PlanetPopulation/KnownRVPlanets.py
+++ b/EXOSIMS/PlanetPopulation/KnownRVPlanets.py
@@ -47,8 +47,6 @@ class KnownRVPlanets(KeplerLike1):
             Orbital period in units of day.  Error in perioderr.
         planetfile (str):
             Name of input file to use
-        rvplanetfilepath (str, optional):
-            Path on disk of planetfile
         tper (astropy Time):
             Periastron time in units of jd.  Error in tpererr.
 

--- a/documentation/EXOSIMS.SurveySimulation.rst
+++ b/documentation/EXOSIMS.SurveySimulation.rst
@@ -9,14 +9,6 @@ EXOSIMS.SurveySimulation package
 Submodules
 ----------
 
-EXOSIMS.SurveySimulation.ExoC\_Scheduler module
------------------------------------------------
-
-.. automodule:: EXOSIMS.SurveySimulation.ExoC_Scheduler
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
 EXOSIMS.SurveySimulation.KnownRVSurvey module
 ---------------------------------------------
 
@@ -29,30 +21,6 @@ EXOSIMS.SurveySimulation.SLSQPScheduler module
 ----------------------------------------------
 
 .. automodule:: EXOSIMS.SurveySimulation.SLSQPScheduler
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
-EXOSIMS.SurveySimulation.SS\_char\_only module
-----------------------------------------------
-
-.. automodule:: EXOSIMS.SurveySimulation.SS_char_only
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
-EXOSIMS.SurveySimulation.SS\_char\_only2 module
------------------------------------------------
-
-.. automodule:: EXOSIMS.SurveySimulation.SS_char_only2
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
-EXOSIMS.SurveySimulation.SS\_det\_only module
----------------------------------------------
-
-.. automodule:: EXOSIMS.SurveySimulation.SS_det_only
    :members:
    :undoc-members:
    :show-inheritance:
@@ -89,26 +57,10 @@ EXOSIMS.SurveySimulation.linearJScheduler\_3DDPC module
    :undoc-members:
    :show-inheritance:
 
-EXOSIMS.SurveySimulation.linearJScheduler\_3DDPC\_sotoSS module
----------------------------------------------------------------
-
-.. automodule:: EXOSIMS.SurveySimulation.linearJScheduler_3DDPC_sotoSS
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
 EXOSIMS.SurveySimulation.linearJScheduler\_DDPC module
 ------------------------------------------------------
 
 .. automodule:: EXOSIMS.SurveySimulation.linearJScheduler_DDPC
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
-EXOSIMS.SurveySimulation.linearJScheduler\_DDPC\_sotoSS module
---------------------------------------------------------------
-
-.. automodule:: EXOSIMS.SurveySimulation.linearJScheduler_DDPC_sotoSS
    :members:
    :undoc-members:
    :show-inheritance:
@@ -121,26 +73,10 @@ EXOSIMS.SurveySimulation.linearJScheduler\_det\_only module
    :undoc-members:
    :show-inheritance:
 
-EXOSIMS.SurveySimulation.linearJScheduler\_det\_only\_sotoSS module
--------------------------------------------------------------------
-
-.. automodule:: EXOSIMS.SurveySimulation.linearJScheduler_det_only_sotoSS
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
 EXOSIMS.SurveySimulation.linearJScheduler\_orbitChar module
 -----------------------------------------------------------
 
 .. automodule:: EXOSIMS.SurveySimulation.linearJScheduler_orbitChar
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
-EXOSIMS.SurveySimulation.linearJScheduler\_sotoSS module
---------------------------------------------------------
-
-.. automodule:: EXOSIMS.SurveySimulation.linearJScheduler_sotoSS
    :members:
    :undoc-members:
    :show-inheritance:
@@ -169,14 +105,6 @@ EXOSIMS.SurveySimulation.randomWalkScheduler2 module
    :undoc-members:
    :show-inheritance:
 
-EXOSIMS.SurveySimulation.starkAYO\_staticSchedule module
---------------------------------------------------------
-
-.. automodule:: EXOSIMS.SurveySimulation.starkAYO_staticSchedule
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
 EXOSIMS.SurveySimulation.tieredScheduler module
 -----------------------------------------------
 
@@ -189,46 +117,6 @@ EXOSIMS.SurveySimulation.tieredScheduler\_DD module
 ---------------------------------------------------
 
 .. automodule:: EXOSIMS.SurveySimulation.tieredScheduler_DD
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
-EXOSIMS.SurveySimulation.tieredScheduler\_DD\_SLSQP module
-----------------------------------------------------------
-
-.. automodule:: EXOSIMS.SurveySimulation.tieredScheduler_DD_SLSQP
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
-EXOSIMS.SurveySimulation.tieredScheduler\_DD\_SS module
--------------------------------------------------------
-
-.. automodule:: EXOSIMS.SurveySimulation.tieredScheduler_DD_SS
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
-EXOSIMS.SurveySimulation.tieredScheduler\_DD\_sotoSS module
------------------------------------------------------------
-
-.. automodule:: EXOSIMS.SurveySimulation.tieredScheduler_DD_sotoSS
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
-EXOSIMS.SurveySimulation.tieredScheduler\_SLSQP module
-------------------------------------------------------
-
-.. automodule:: EXOSIMS.SurveySimulation.tieredScheduler_SLSQP
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
-EXOSIMS.SurveySimulation.tieredScheduler\_sotoSS module
--------------------------------------------------------
-
-.. automodule:: EXOSIMS.SurveySimulation.tieredScheduler_sotoSS
    :members:
    :undoc-members:
    :show-inheritance:

--- a/documentation/arglist.rst
+++ b/documentation/arglist.rst
@@ -40,13 +40,15 @@ The table below includes a list of all Prototype module inputs.
       - :py:class:`~EXOSIMS.MissionSim.MissionSim`
     * - ``checkKeepoutEnd``
       - :py:class:`~EXOSIMS.Prototypes.Observatory.Observatory`
+    * - ``cherryPickStars``
+      - :py:class:`~EXOSIMS.Prototypes.TargetList.TargetList`
     * - ``coMass``
       - :py:class:`~EXOSIMS.Prototypes.Observatory.Observatory`
     * - ``commonSystemfEZ``
       - :py:class:`~EXOSIMS.Prototypes.ZodiacalLight.ZodiacalLight`
-    * - ``commonSystemInclinationParams``
+    * - ``commonSystemPlane``
       - :py:class:`~EXOSIMS.Prototypes.SimulatedUniverse.SimulatedUniverse`
-    * - ``commonSystemInclinations``
+    * - ``commonSystemPlaneParams``
       - :py:class:`~EXOSIMS.Prototypes.SimulatedUniverse.SimulatedUniverse`
     * - ``constrainOrbits``
       - :py:class:`~EXOSIMS.Prototypes.PlanetPopulation.PlanetPopulation`
@@ -115,8 +117,6 @@ The table below includes a list of all Prototype module inputs.
     * - ``input_angle_units``
       - :py:class:`~EXOSIMS.Prototypes.OpticalSystem.OpticalSystem`
     * - ``int_dMag``
-      - :py:class:`~EXOSIMS.Prototypes.TargetList.TargetList`
-    * - ``int_dMag_offset``
       - :py:class:`~EXOSIMS.Prototypes.TargetList.TargetList`
     * - ``int_WA``
       - :py:class:`~EXOSIMS.Prototypes.TargetList.TargetList`
@@ -254,6 +254,8 @@ The table below includes a list of all Prototype module inputs.
       - :py:class:`~EXOSIMS.Prototypes.Observatory.Observatory`
     * - ``skEff``
       - :py:class:`~EXOSIMS.Prototypes.Observatory.Observatory`
+    * - ``skipSaturationCalcs``
+      - :py:class:`~EXOSIMS.Prototypes.TargetList.TargetList`
     * - ``skIsp``
       - :py:class:`~EXOSIMS.Prototypes.Observatory.Observatory`
     * - ``skMass``


### PR DESCRIPTION
## Describe your changes

Adds  `cherryPickStars` and `skipSaturationCalcs` as inputs and attributes tot the `TargetList prototype`

Also cleans up the docstring in PlanetPopulation/KnownRVPlanets and updates all docs.

## Type of change

- New feature (non-breaking change which adds functionality)
- This change requires a documentation update

## Reference any relevant issues (don't forget the #)
N/A

## Checklist before requesting a review
- [x] I have verified that all unit tests pass in a clean virtual environment and added new unit tests, as needed
- [x] I have run ``e2eTests`` and added new test scripts, as needed
- [x] I have verified that all docstrings are properly formatted and added new documentation, as needed
