### PR TITLE
Filtermode

### DIFF
--- a/EXOSIMS/Completeness/SubtypeCompleteness.py
+++ b/EXOSIMS/Completeness/SubtypeCompleteness.py
@@ -266,7 +266,7 @@ class SubtypeCompleteness(BrownCompleteness):
             ]
 
         # limiting planet delta magnitude for completeness
-        dMagMax = max(TL.saturation_dMag)
+        dMagMax = max(TL.intCutoff_dMag)
 
         int_comp = np.zeros(smin.shape)
         if self.PlanetPopulation.scaleOrbits:
@@ -304,7 +304,7 @@ class SubtypeCompleteness(BrownCompleteness):
         PPop = TL.PlanetPopulation
 
         # limiting planet delta magnitude for completeness
-        dMagMax = max(TL.saturation_dMag)
+        dMagMax = max(TL.intCutoff_dMag)
 
         # get name for stored dynamic completeness updates array
         # inner and outer working angles for detection mode

--- a/EXOSIMS/Prototypes/SurveySimulation.py
+++ b/EXOSIMS/Prototypes/SurveySimulation.py
@@ -1883,7 +1883,7 @@ class SurveySimulation(object):
         ]
 
         # in case of a FA, generate a random delta mag (between PPro.FAdMag0 and
-        # TL.saturation_dMag) and working angle (between IWA and min(OWA, a_max))
+        # TL.intCutoff_dMag) and working angle (between IWA and min(OWA, a_max))
         if FA:
             WA = (
                 np.random.uniform(
@@ -1894,7 +1894,7 @@ class SurveySimulation(object):
                 )
                 * u.arcsec
             )
-            dMag = np.random.uniform(PPro.FAdMag0(WA), TL.saturation_dMag)
+            dMag = np.random.uniform(PPro.FAdMag0(WA), TL.intCutoff_dMag)
             self.lastDetected[sInd, 0] = np.append(self.lastDetected[sInd, 0], True)
             self.lastDetected[sInd, 1] = np.append(
                 self.lastDetected[sInd, 1], ZL.fEZ0.to("1/arcsec2").value

--- a/EXOSIMS/Prototypes/TargetList.py
+++ b/EXOSIMS/Prototypes/TargetList.py
@@ -433,7 +433,7 @@ class TargetList(object):
             int_WA = (
                 2.0 * self.filter_mode["IWA"]
                 if np.isinf(self.filter_mode["OWA"])
-                else (self.filter_mode["IWA"] + self.fitler_mode["OWA"]) / 2.0
+                else (self.filter_mode["IWA"] + self.filter_mode["OWA"]) / 2.0
             )
             int_WA = int_WA.to("arcsec")
 

--- a/EXOSIMS/Prototypes/TargetList.py
+++ b/EXOSIMS/Prototypes/TargetList.py
@@ -245,10 +245,10 @@ class TargetList(object):
             Rescale int_dMag and int_WA for all stars based on luminosity and to ensure
             that WA is within the IWA/OWA.
         skipSaturationCalcs (bool):
-            If True, saturation dMag and saturation completeness are not computed. If
-            cached values exist, they will be loaded, otherwise saturation_dMag and
-            saturation_comp will all be set to NaN.  No new cache files will be written
-            for these values.
+            If True (default), saturation dMag and saturation completeness are not
+            computed. If cached values exist, they will be loaded, otherwise
+            saturation_dMag and saturation_comp will all be set to NaN.  No new cache
+            files will be written for these values.
         Spec (numpy.ndarray):
             Spectral type strings. Will be strictly in G0V format.
         specdict (dict):
@@ -315,7 +315,7 @@ class TargetList(object):
         scaleWAdMag=False,
         popStars=None,
         cherryPickStars=None,
-        skipSaturationCalcs=False,
+        skipSaturationCalcs=True,
         **specs,
     ):
 

--- a/EXOSIMS/Prototypes/TargetList.py
+++ b/EXOSIMS/Prototypes/TargetList.py
@@ -140,9 +140,6 @@ class TargetList(object):
             :ref:`Completeness` object
         coords (astropy.coordinates.sky_coordinate.SkyCoord):
             Target coordinates
-        default_mode (dict):
-            :ref:`OpticalSystem` observingMode dictionary.  Either the detection mode
-            (default) or first characterization mode (if ``filter_for_char`` is True).
         diameter (astropy.units.quantity.Quantity):
             Stellar diameter in angular units.
         dist (astropy.units.quantity.Quantity):
@@ -164,6 +161,10 @@ class TargetList(object):
         filterBinaries (bool):
             Remove all binary stars or stars with known close companions from target
             list.
+        filter_mode (dict):
+            :ref:`OpticalSystem` observingMode dictionary. The observingMode used for
+            target filtering.  Either the detection mode (default) or first
+            characterization mode (if ``filter_for_char`` is True).
         getKnownPlanets (bool):
             Grab the list of known planets and target aliases from the NASA Exoplanet
             Archive
@@ -408,19 +409,31 @@ class TargetList(object):
             self.PlanetPopulation = self.Completeness.PlanetPopulation
             self.PlanetPhysicalModel = self.Completeness.PlanetPhysicalModel
 
-        # identify default detection mode
+        # identify the observingMode to use for target filtering
         detmode = list(
             filter(
                 lambda mode: mode["detectionMode"], self.OpticalSystem.observingModes
             )
         )[0]
+        if self.filter_for_char or self.earths_only:
+            mode = list(
+                filter(
+                    lambda mode: "spec" in mode["inst"]["name"],
+                    self.OpticalSystem.observingModes,
+                )
+            )[0]
+            self.calc_char_int_comp = True
+        else:
+            mode = detmode
+            self.calc_char_int_comp = False
+        self.filter_mode = mode
 
         # Define int_WA if None provided
         if int_WA is None:
             int_WA = (
-                2.0 * detmode["IWA"]
-                if np.isinf(detmode["OWA"])
-                else (detmode["IWA"] + detmode["OWA"]) / 2.0
+                2.0 * self.filter_mode["IWA"]
+                if np.isinf(self.filter_mode["OWA"])
+                else (self.filter_mode["IWA"] + self.fitler_mode["OWA"]) / 2.0
             )
             int_WA = int_WA.to("arcsec")
 
@@ -511,30 +524,24 @@ class TargetList(object):
         # star fluxes for the detection mode.  Let's do that now (post-filtering to
         # limit the number of calculations
         if self.filter_for_char or self.earths_only:
-            mode = list(
-                filter(
-                    lambda mode: mode["detectionMode"],
-                    self.OpticalSystem.observingModes,
-                )
-            )[0]
             fname = (
                 f"TargetList_{self.StarCatalog.__class__.__name__}_"
-                f"nStars_{self.nStars}_mode_{mode['hex']}.star_fluxes"
+                f"nStars_{self.nStars}_mode_{detmode['hex']}.star_fluxes"
             )
             star_flux_path = Path(self.cachedir, fname)
             if star_flux_path.exists():
                 with open(star_flux_path, "rb") as f:
-                    self.star_fluxes[mode["hex"]] = pickle.load(f)
+                    self.star_fluxes[detmode["hex"]] = pickle.load(f)
                 self.vprint(f"Loaded star fluxes values from {star_flux_path}")
             else:
-                _ = self.starFlux(np.arange(self.nStars), mode)
+                _ = self.starFlux(np.arange(self.nStars), detmode)
                 with open(star_flux_path, "wb") as f:
-                    pickle.dump(self.star_fluxes[mode["hex"]], f)
+                    pickle.dump(self.star_fluxes[detmode["hex"]], f)
                     self.vprint(f"Star fluxes stored in {star_flux_path}")
 
             # remove any zero-flux vals
-            if np.any(self.star_fluxes[mode["hex"]].value == 0):
-                keepinds = np.where(self.star_fluxes[mode["hex"]].value != 0)[0]
+            if np.any(self.star_fluxes[detmode["hex"]].value == 0):
+                keepinds = np.where(self.star_fluxes[detmode["hex"]].value != 0)[0]
                 self.revise_lists(keepinds)
                 if self.explainFiltering:
                     print(
@@ -864,43 +871,37 @@ class TargetList(object):
         ZL = self.ZodiacalLight
         PPop = self.PlanetPopulation
         Comp = self.Completeness
-        detmode = list(filter(lambda mode: mode["detectionMode"], OS.observingModes))[0]
-        if self.filter_for_char or self.earths_only:
-            mode = list(
-                filter(lambda mode: "spec" in mode["inst"]["name"], OS.observingModes)
-            )[0]
-            self.calc_char_int_comp = True
-        else:
-            mode = detmode
-            self.calc_char_int_comp = False
-        self.default_mode = mode
 
         # grab zodi vals for any required calculations
         sInds = np.arange(self.nStars)
-        fZminglobal = ZL.global_zodi_min(mode)
+        fZminglobal = ZL.global_zodi_min(self.filter_mode)
         fZ = np.repeat(fZminglobal, len(sInds))
-        fEZ = np.repeat(ZL.fEZ0, len(sInds))
+        fEZ = (
+            ZL.zodi_color_correction_factor(self.filter_mode["lam"], photon_units=True)
+            * ZL.fEZ0
+            * 10.0 ** (-0.4 * (self.MV - 4.83))
+        )
 
         # compute proj separation bounds for any required calculations
         if PPop.scaleOrbits:
-            tmp_smin = np.tan(mode["IWA"]) * self.dist / np.sqrt(self.L)
-            if np.isinf(mode["OWA"]):
+            tmp_smin = np.tan(self.filter_mode["IWA"]) * self.dist / np.sqrt(self.L)
+            if np.isinf(self.filter_mode["OWA"]):
                 tmp_smax = np.inf * self.dist
             else:
-                tmp_smax = np.tan(mode["OWA"]) * self.dist / np.sqrt(self.L)
+                tmp_smax = np.tan(self.filter_mode["OWA"]) * self.dist / np.sqrt(self.L)
         else:
-            tmp_smin = np.tan(mode["IWA"]) * self.dist
-            if np.isinf(mode["OWA"]):
+            tmp_smin = np.tan(self.filter_mode["IWA"]) * self.dist
+            if np.isinf(self.filter_mode["OWA"]):
                 tmp_smax = np.inf * self.dist
             else:
-                tmp_smax = np.tan(mode["OWA"]) * self.dist
+                tmp_smax = np.tan(self.filter_mode["OWA"]) * self.dist
 
         # 0. Regardless of whatever else we do, we're going to need stellar fluxes in
         # the relevant observing mode.  So let's just compute them now and cache them
         # for later use.
         fname = (
             f"TargetList_{self.StarCatalog.__class__.__name__}_"
-            f"nStars_{self.nStars}_mode_{mode['hex']}.star_fluxes"
+            f"nStars_{self.nStars}_mode_{self.filter_mode['hex']}.star_fluxes"
         )
         star_flux_path = Path(self.cachedir, fname)
         if star_flux_path.exists():
@@ -908,14 +909,14 @@ class TargetList(object):
                 self.star_fluxes = pickle.load(f)
             self.vprint(f"Loaded star fluxes values from {star_flux_path}")
         else:
-            _ = self.starFlux(np.arange(self.nStars), mode)
+            _ = self.starFlux(np.arange(self.nStars), self.filter_mode)
             with open(star_flux_path, "wb") as f:
                 pickle.dump(self.star_fluxes, f)
                 self.vprint(f"Star fluxes stored in {star_flux_path}")
 
         # remove any zero-flux vals
-        if np.any(self.star_fluxes[mode["hex"]].value == 0):
-            keepinds = np.where(self.star_fluxes[mode["hex"]].value != 0)[0]
+        if np.any(self.star_fluxes[self.filter_mode["hex"]].value == 0):
+            keepinds = np.where(self.star_fluxes[self.filter_mode["hex"]].value != 0)[0]
             self.revise_lists(keepinds)
             sInds = np.arange(self.nStars)
             tmp_smin = tmp_smin[keepinds]
@@ -932,7 +933,7 @@ class TargetList(object):
         # 1. Calculate the saturation dMag. This is stricly a function of
         # fZminglobal, ZL.fEZ0, self.int_WA, mode, the current targetlist
         # and the postprocessing factor
-        zodi_vals_str = f"{str(ZL.global_zodi_min(mode))} {str(ZL.fEZ0)}"
+        zodi_vals_str = f"{str(ZL.global_zodi_min(self.filter_mode))} {str(ZL.fEZ0)}"
         stars_str = (
             f"ppFact:{self.PostProcessing._outspec['ppFact']}, "
             f"fillPhotometry:{self.fillPhotometry}, "
@@ -946,7 +947,7 @@ class TargetList(object):
         fname = (
             f"TargetList_{self.StarCatalog.__class__.__name__}_"
             f"{OS.__class__.__name__}_{ZL.__class__.__name__}_"
-            f"vals_{vals_hash}_mode_{mode['hex']}"
+            f"vals_{vals_hash}_mode_{self.filter_mode['hex']}"
         )
 
         saturation_dMag_path = Path(self.cachedir, f"{fname}.sat_dMag")
@@ -959,7 +960,7 @@ class TargetList(object):
                 self.saturation_dMag = np.zeros(self.nStars) * np.nan
             else:
                 self.saturation_dMag = OS.calc_saturation_dMag(
-                    self, sInds, fZ, fEZ, self.int_WA, mode, TK=None
+                    self, sInds, fZ, fEZ, self.int_WA, self.filter_mode, TK=None
                 )
 
                 with open(saturation_dMag_path, "wb") as f:
@@ -1013,7 +1014,7 @@ class TargetList(object):
         fname = (
             f"TargetList_{self.StarCatalog.__class__.__name__}_"
             f"{OS.__class__.__name__}_{ZL.__class__.__name__}_"
-            f"vals_{vals_hash}_mode_{mode['hex']}"
+            f"vals_{vals_hash}_mode_{self.filter_mode['hex']}"
         )
 
         intCutoff_dMag_path = Path(self.cachedir, f"{fname}.intCutoff_dMag")
@@ -1026,7 +1027,7 @@ class TargetList(object):
             intTimes = np.repeat(OS.intCutoff.value, len(sInds)) * OS.intCutoff.unit
 
             self.intCutoff_dMag = OS.calc_dMag_per_intTime(
-                intTimes, self, sInds, fZ, fEZ, self.int_WA, mode
+                intTimes, self, sInds, fZ, fEZ, self.int_WA, self.filter_mode
             ).reshape((len(intTimes),))
             with open(intCutoff_dMag_path, "wb") as f:
                 pickle.dump(self.intCutoff_dMag, f)
@@ -1093,12 +1094,12 @@ class TargetList(object):
             self.int_WA = ((np.sqrt(self.L) * u.AU / self.dist).decompose() * u.rad).to(
                 u.arcsec
             )
-            self.int_WA[np.where(self.int_WA > detmode["OWA"])[0]] = detmode["OWA"] * (
-                1.0 - 1e-14
-            )
-            self.int_WA[np.where(self.int_WA < detmode["IWA"])[0]] = detmode["IWA"] * (
-                1.0 + 1e-14
-            )
+            self.int_WA[
+                np.where(self.int_WA > self.filter_mode["OWA"])[0]
+            ] = self.filter_mode["OWA"] * (1.0 - 1e-14)
+            self.int_WA[
+                np.where(self.int_WA < self.filter_mode["IWA"])[0]
+            ] = self.filter_mode["IWA"] * (1.0 + 1e-14)
             self.int_dMag = self.int_dMag + 2.5 * np.log10(self.L)
 
         # Go through the int_dMag values and replace with limiting dMag where
@@ -1110,7 +1111,7 @@ class TargetList(object):
 
         # Finally, compute the nominal integration time at minimum zodi
         self.int_tmin = self.OpticalSystem.calc_intTime(
-            self, sInds, fZ, fEZ, self.int_dMag, self.int_WA, mode
+            self, sInds, fZ, fEZ, self.int_dMag, self.int_WA, self.filter_mode
         )
 
         # update catalog attributes for any future filtering

--- a/tests/OpticalSystem/test_OpticalSystem.py
+++ b/tests/OpticalSystem/test_OpticalSystem.py
@@ -198,7 +198,7 @@ class TestOpticalSystem(unittest.TestCase):
             # recalculate it with the current module
             tmpspec = copy.deepcopy(self.spec)
             tmpspec["modules"]["OpticalSystem"] = mod.__name__
-            TL = TargetList(ntargs=10, **tmpspec)
+            TL = TargetList(ntargs=10, skipSaturationCalcs=False, **tmpspec)
 
             obj = TL.OpticalSystem
             # make sure all dMags are lower than the saturation dMag


### PR DESCRIPTION
## Describe your changes

Deprecating `TargetList.default_mode` and replacing with `TargetList.filter_mode`.  All internal `TargetList` calculations (for integration times and dMags, etc.) now use the `filter_mode` attribute.  

Update exozodi values used for saturation & intCutoff calculations to be properly scaled by MV and the color correction for the appropriate observing mode. 

## Type of change

Please delete options that are not relevant (and this line).

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- This change requires a documentation update

## Checklist before requesting a review
- [x] I have verified that all unit tests pass in a clean virtual environment and added new unit tests, as needed
- [x] I have run ``e2eTests`` and added new test scripts, as needed
- [x] I have verified that all docstrings are properly formatted and added new documentation, as needed
