### PR TITLE
Multiply the "timeMultiplier" into the calculated integration time in Nemati OpticalSystem. 

### DIFF
--- a/EXOSIMS/OpticalSystem/Nemati.py
+++ b/EXOSIMS/OpticalSystem/Nemati.py
@@ -251,10 +251,11 @@ class Nemati(OpticalSystem):
         with np.errstate(divide="ignore", invalid="ignore"):
             if mode["syst"]["occulter"] is False:
                 intTime = np.true_divide(
-                    SNR**2.0 * C_b, (C_p**2.0 - (SNR * C_sp) ** 2.0)
-                ).to("day")
+                    mode["timeMultiplier"] * SNR**2.0 * C_b,
+                    (C_p**2.0 - (SNR * C_sp) ** 2.0)).to("day")
             else:
-                intTime = np.true_divide(SNR**2.0 * C_b, (C_p**2.0)).to("day")
+                intTime = np.true_divide(mode["timeMultiplier"] *
+                                         SNR**2.0 * C_b, (C_p**2.0)).to("day")
         # infinite and NAN are set to zero
         intTime[np.isinf(intTime) | np.isnan(intTime)] = np.nan
         # negative values are set to zero

--- a/EXOSIMS/OpticalSystem/Nemati.py
+++ b/EXOSIMS/OpticalSystem/Nemati.py
@@ -255,6 +255,8 @@ class Nemati(OpticalSystem):
                 ).to("day")
             else:
                 intTime = np.true_divide(SNR**2.0 * C_b, (C_p**2.0)).to("day")
+            # multiply the calculated intTime by the "timeMultiplier"
+            intTime *= mode["timeMultiplier"]
         # infinite and NAN are set to zero
         intTime[np.isinf(intTime) | np.isnan(intTime)] = np.nan
         # negative values are set to zero

--- a/EXOSIMS/OpticalSystem/Nemati.py
+++ b/EXOSIMS/OpticalSystem/Nemati.py
@@ -251,11 +251,10 @@ class Nemati(OpticalSystem):
         with np.errstate(divide="ignore", invalid="ignore"):
             if mode["syst"]["occulter"] is False:
                 intTime = np.true_divide(
-                    mode["timeMultiplier"] * SNR**2.0 * C_b,
-                    (C_p**2.0 - (SNR * C_sp) ** 2.0)).to("day")
+                    SNR**2.0 * C_b, (C_p**2.0 - (SNR * C_sp) ** 2.0)
+                ).to("day")
             else:
-                intTime = np.true_divide(mode["timeMultiplier"] *
-                                         SNR**2.0 * C_b, (C_p**2.0)).to("day")
+                intTime = np.true_divide(SNR**2.0 * C_b, (C_p**2.0)).to("day")
         # infinite and NAN are set to zero
         intTime[np.isinf(intTime) | np.isnan(intTime)] = np.nan
         # negative values are set to zero


### PR DESCRIPTION
## Describe your changes
Add a line in the Nemati OpticalSystem to multiply the "timeMultiplier" into the calculated integration time. 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Reference any relevant issues (don't forget the #)

Fixes #369 

## Checklist before requesting a review
- [x] I have verified that all unit tests pass in a clean virtual environment and added new unit tests, as needed
- [x] I have run ``e2eTests`` and added new test scripts, as needed
- [x] I have verified that all docstrings are properly formatted and added new documentation, as needed
