### PR TITLE
Python 3.12 compatibility

### DIFF
--- a/EXOSIMS/__init__.py
+++ b/EXOSIMS/__init__.py
@@ -1,7 +1,7 @@
 import logging
 
 name = "EXOSIMS"
-__version__ = "3.2.2"
+__version__ = "3.3.0"
 
 # Set up a default logging handler to avoid "No handler found" warnings.
 # Other handlers can add to this one.

--- a/EXOSIMS/util/get_module.py
+++ b/EXOSIMS/util/get_module.py
@@ -3,7 +3,6 @@ import os.path
 import inspect
 import importlib
 import pkgutil
-import imp
 import sys
 
 # local indicator of verbosity: False is the typical non-debug setting
@@ -247,7 +246,8 @@ def get_module(name, folder=None, silent=False):
             raise ValueError('Could not load module from path "%s".' % path)
         # the module is loaded under this name
         module_name_to_use = os.path.splitext(os.path.basename(path))[0]
-        full_module = imp.load_source(module_name_to_use, path)
+        modspec = importlib.util.spec_from_file_location(module_name_to_use, path)
+        full_module = importlib.util.module_from_spec(modspec)
         source = path
         note = "named file"
     else:

--- a/EXOSIMS/util/get_module.py
+++ b/EXOSIMS/util/get_module.py
@@ -248,6 +248,7 @@ def get_module(name, folder=None, silent=False):
         module_name_to_use = os.path.splitext(os.path.basename(path))[0]
         modspec = importlib.util.spec_from_file_location(module_name_to_use, path)
         full_module = importlib.util.module_from_spec(modspec)
+        modspec.loader.exec_module(full_module)
         source = path
         note = "named file"
     else:

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Credits and Acknowledgements
 ------------------------------
 Created by Dmitry Savransky
 
-Written by Christian Delacroix, Daniel Garrett, Dean Keithly, Gabriel Soto, Corey Spohn, Walker Dula, Sonny Rappaport, Michael Turmon, Rhonda Morgan, Grace Genszler, and Dmitry Savransky, with contributions by Patrick Lowrance, Ewan Douglas, Jackson Kulik, Jeremy Turner, Jayson Figueroa, Owen Sorber and Neil Zimmerman.
+Written by Christian Delacroix, Daniel Garrett, Dean Keithly, Gabriel Soto, Corey Spohn, Walker Dula, Sonny Rappaport, Michael Turmon, Rhonda Morgan, Grace Genszler, and Dmitry Savransky, with contributions by Patrick Lowrance, Ewan Douglas, Jackson Kulik, Jeremy Turner, Jayson Figueroa, Owen Sorber, Maxwell Zweig, and Neil Zimmerman.
 
 EXOSIMS makes use of Astropy, a community-developed core Python package for Astronomy (Astropy Collaboration, 2013).
 

--- a/setup.py
+++ b/setup.py
@@ -55,6 +55,7 @@ setuptools.setup(
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
         "License :: OSI Approved :: BSD License",
         "Operating System :: OS Independent",
     ],


### PR DESCRIPTION
## Describe your changes
Removing deprecated imp import and replacing with equivalent importlib functionality.  Now formally supporting Python 3.12

## Type of change

Please delete options that are not relevant (and this line).

- Bug fix (non-breaking change which fixes an issue)

## Checklist before requesting a review
- [x] I have verified that all unit tests pass in a clean virtual environment and added new unit tests, as needed
- [x] I have run ``e2eTests`` and added new test scripts, as needed
- [x] I have verified that all docstrings are properly formatted and added new documentation, as needed
