### PR TITLE
TargetList filtering change

### DIFF
--- a/EXOSIMS/Prototypes/OpticalSystem.py
+++ b/EXOSIMS/Prototypes/OpticalSystem.py
@@ -581,7 +581,7 @@ class OpticalSystem(object):
                 warnings.warn(
                     f'Input FoV ({inst["FoV"]}) is larger than FoV computed '
                     f"from pixelScale ({predFoV.to(u.arcsec) :.2f}) for "
-                    f'instrument {inst["name"]}. This feels like a mistkae.'
+                    f'instrument {inst["name"]}. This feels like a mistake.'
                 )
 
             # parameters specific to spectrograph

--- a/EXOSIMS/Prototypes/TargetList.py
+++ b/EXOSIMS/Prototypes/TargetList.py
@@ -365,8 +365,8 @@ class TargetList(object):
 
         # Set up optional filters
         default_filters = {
-            "outside_IWA_filter": {"enabled": True, "params": {}},
-            "completeness_filter": {"enabled": True, "params": {}},
+            "outside_IWA_filter": {"enabled": True},
+            "completeness_filter": {"enabled": True},
         }
         # Add the binary filter to the default optional filters
         if optional_filters.get("binary_filter"):
@@ -379,12 +379,10 @@ class TargetList(object):
                     f"Using binary_filter value of {optional_filters.get('enabled')}."
                 )
         else:
-            default_filters["binary_filter"] = {
-                "enabled": self.filterBinaries,
-                "params": {},
-            }
-        # Add the provided optional filters to the default filters and then
-        # save the combined dictionary as a class attribute
+            default_filters["binary_filter"] = {"enabled": self.filterBinaries}
+        # Add the provided optional filters to the default filters, overriding
+        # the defaults if necessary, and then save the combined dictionary as a
+        # class attribute
         default_filters.update(optional_filters)
         self.optional_filters = default_filters
 

--- a/EXOSIMS/Prototypes/TargetList.py
+++ b/EXOSIMS/Prototypes/TargetList.py
@@ -1431,7 +1431,13 @@ class TargetList(object):
                     )
 
     def vmag_filter(self, vmag_range):
-        """Removes stars which have attribute Binary_Cut == True"""
+        """Removes stars with Vmag outside of specified range
+
+        Args:
+            vmag_range (list):
+                2-element list of min, max Vmag values
+
+        """
         meets_lower_bound = self.Vmag > vmag_range[0]
         meets_upper_bound = self.Vmag < vmag_range[1]
         i = np.where(meets_lower_bound & meets_upper_bound)[0]

--- a/EXOSIMS/Prototypes/TargetList.py
+++ b/EXOSIMS/Prototypes/TargetList.py
@@ -638,11 +638,9 @@ class TargetList(object):
             allInds = np.arange(self.nStars, dtype=int)
             missionStart = Time(float(missionStart), format="mjd", scale="tai")
             self.starprop_static = (
-                lambda sInds,
-                currentTime,
-                eclip=False,
-                c1=self.starprop(allInds, missionStart, eclip=False),
-                c2=self.starprop(allInds, missionStart, eclip=True): (
+                lambda sInds, currentTime, eclip=False, c1=self.starprop(
+                    allInds, missionStart, eclip=False
+                ), c2=self.starprop(allInds, missionStart, eclip=True): (
                     c1[sInds] if not (eclip) else c2[sInds]  # noqa: E275
                 )
             )

--- a/EXOSIMS/Prototypes/TargetList.py
+++ b/EXOSIMS/Prototypes/TargetList.py
@@ -366,7 +366,7 @@ class TargetList(object):
         # Set up optional filters
         default_filters = {
             "outside_IWA_filter": {"enabled": True, "params": {}},
-            "completness_filter": {"enabled": True, "params": {}},
+            "completeness_filter": {"enabled": True, "params": {}},
         }
         # Add the binary filter to the default optional filters
         if optional_filters.get("binary_filter"):

--- a/EXOSIMS/Prototypes/TargetList.py
+++ b/EXOSIMS/Prototypes/TargetList.py
@@ -531,11 +531,17 @@ class TargetList(object):
         self.fillPhotometryVals()
 
         # filter out nan attribute values from Star Catalog
-        mandatory_filters = {
-            "nan_filter": {"enabled": True},
-            "zero_lum_filter": {"enabled": True},
-        }
-        self.filter_target_list(mandatory_filters)
+        self.nan_filter()
+        if self.explainFiltering:
+            print("%d targets remain after nan filtering." % self.nStars)
+
+        # filter out target stars with 0 luminosity
+        self.zero_lum_filter()
+        if self.explainFiltering:
+            print(
+                "%d targets remain after removing zero luminosity targets."
+                % self.nStars
+            )
 
         # compute stellar effective temperatures as needed
         self.stellar_Teff()

--- a/EXOSIMS/Prototypes/TargetList.py
+++ b/EXOSIMS/Prototypes/TargetList.py
@@ -225,6 +225,9 @@ class TargetList(object):
             Base longitude of the ascending node for target system orbital planes
         OpticalSystem (:ref:`OpticalSystem`):
             :ref:`OpticalSystem` object
+        optional_filters (dict):
+            Dictionary of optional filters to apply to the target list.  Keys are the
+            filter's name and values are the values necessary to apply the filter.
         parx (astropy.units.quantity.Quantity):
             Parallaxes
         PlanetPhysicalModel (:ref:`PlanetPhysicalModel`):
@@ -326,6 +329,7 @@ class TargetList(object):
         cherryPickStars=None,
         skipSaturationCalcs=True,
         massLuminosityRelationship="Henry1993",
+        optional_filters={},
         **specs,
     ):
         # start the outspec
@@ -358,6 +362,31 @@ class TargetList(object):
             "Henry1993+1999",
             "Fang2010",
         ]
+
+        # Set up optional filters
+        default_filters = {
+            "outside_IWA_filter": {"enabled": True, "params": {}},
+            "completness_filter": {"enabled": True, "params": {}},
+        }
+        # Add the binary filter to the default optional filters
+        if optional_filters.get("binary_filter"):
+            # if binary_filter is provided in the optional_filters dict, we use that
+            # value but raise a warning if it conflicts with the set filter value.
+            if self.filterBinaries != optional_filters.get("enabled"):
+                warnings.warn(
+                    f"binary_filter is {optional_filters.get('enabled')} "
+                    f"but filterBinaries is {self.filterBinaries}. "
+                    f"Using binary_filter value of {optional_filters.get('enabled')}."
+                )
+        else:
+            default_filters["binary_filter"] = {
+                "enabled": self.filterBinaries,
+                "params": {},
+            }
+        # Add the provided optional filters to the default filters and then
+        # save the combined dictionary as a class attribute
+        default_filters.update(optional_filters)
+        self.optional_filters = default_filters
 
         assert (
             self.massLuminosityRelationship in allowable_massLuminosityRelationships
@@ -502,17 +531,11 @@ class TargetList(object):
         self.fillPhotometryVals()
 
         # filter out nan attribute values from Star Catalog
-        self.nan_filter()
-        if self.explainFiltering:
-            print("%d targets remain after nan filtering." % self.nStars)
-
-        # filter out target stars with 0 luminosity
-        self.zero_lum_filter()
-        if self.explainFiltering:
-            print(
-                "%d targets remain after removing zero luminosity targets."
-                % self.nStars
-            )
+        mandatory_filters = {
+            "nan_filter": {"enabled": True},
+            "zero_lum_filter": {"enabled": True},
+        }
+        self.filter_target_list(mandatory_filters)
 
         # compute stellar effective temperatures as needed
         self.stellar_Teff()
@@ -530,6 +553,15 @@ class TargetList(object):
         self.blackbody_spectra = np.ndarray((self.nStars), dtype=object)
         self.catalog_atts.append("blackbody_spectra")
 
+        # Apply optional filters that don't depend on completeness
+        secondary_filter_names = ["completeness_filter"]
+        first_filter_set = {
+            key: self.optional_filters.get(key, {})
+            for key in self.optional_filters.keys()
+            if key not in secondary_filter_names
+        }
+        self.filter_target_list(first_filter_set)
+
         # Calculate saturation and intCutoff delta mags and completeness values
         self.calc_saturation_and_intCutoff_vals()
 
@@ -540,8 +572,11 @@ class TargetList(object):
         # generate any completeness update data needed
         self.Completeness.gen_update(self)
 
-        # apply any requested additional filters
-        self.filter_target_list(**specs)
+        # apply any requested additional filters that depend on completeness
+        second_filter_set = {
+            key: self.optional_filters.get(key, {}) for key in secondary_filter_names
+        }
+        self.filter_target_list(second_filter_set)
 
         # if we're doing filter_for_char, then that means that we haven't computed the
         # star fluxes for the detection mode.  Let's do that now (post-filtering to
@@ -597,9 +632,11 @@ class TargetList(object):
             allInds = np.arange(self.nStars, dtype=int)
             missionStart = Time(float(missionStart), format="mjd", scale="tai")
             self.starprop_static = (
-                lambda sInds, currentTime, eclip=False, c1=self.starprop(
-                    allInds, missionStart, eclip=False
-                ), c2=self.starprop(allInds, missionStart, eclip=True): (
+                lambda sInds,
+                currentTime,
+                eclip=False,
+                c1=self.starprop(allInds, missionStart, eclip=False),
+                c2=self.starprop(allInds, missionStart, eclip=True): (
                     c1[sInds] if not (eclip) else c2[sInds]  # noqa: E275
                 )
             )
@@ -1346,34 +1383,66 @@ class TargetList(object):
                         + mag_to_add[i]
                     )
 
-    def filter_target_list(self, **specs):
+    def filter_target_list(self, filters):
         """This function is responsible for filtering by any required metrics.
 
-        The prototype implementation removes the following stars:
-            * Stars with NAN values in their parameters
-            * Binary stars
-            * Systems with planets inside the OpticalSystem fundamental IWA
-            * Systems where minimum integration time is longer than OpticalSystem cutoff
-            * Systems not meeting the Completeness threshold
+        This should be used for *optional* filters. The ones in the prototype
+        are:
+            binary_filter
+            outside_IWA_filter
+            life_expectancy_filter
+            main_sequence_filter
+            fgk_filter
+            vis_mag_filter (takes Vmagcrit as input)
+            max_dmag_filter
+            completeness_filter (Has to be run after the completeness values are calculated)
+            vmag_filter (takes vmag_range as input)
+            ang_diam_filter
 
-        Additional filters can be provided in specific TargetList implementations.
-
+        Args:
+            filters (dict):
+                Dictionary of filters to apply to the target list.  Keys are
+                filter names, and values are the filter functions to apply.
+                Looks like:
+                filters = {
+                    "binary_filter": {"enabled": True},
+                    "outside_IWA_filter": {"enabled": True},
+                    vmag_filter: {"enabled": True, "params": {"vmag_range": [4, 10]}},
+                }
         """
-        # filter out binary stars
-        if self.filterBinaries:
-            self.binary_filter()
-            if self.explainFiltering:
-                print("%d targets remain after binary filter." % self.nStars)
+        for filter_name, filter_config in filters.items():
+            # check if the filter is enabled
+            if filter_config.get("enabled", False):
+                # get the filter function
+                if hasattr(self, filter_name):
+                    # Get the filter method
+                    filter_func = getattr(self, filter_name)
+                    # Apply the filter
+                    filter_func(**filter_config.get("params", {}))
+                    if self.explainFiltering:
+                        print(
+                            f"{self.nStars} targets remain after {filter_name.replace('_', ' ')}."
+                        )
+                else:
+                    raise AttributeError(
+                        (f"No filter '{filter_name}' in {self.__class__.__name__}.")
+                    )
 
-        # filter out systems with planets within the IWA
-        self.outside_IWA_filter()
-        if self.explainFiltering:
-            print("%d targets remain after IWA filter." % self.nStars)
+    def vmag_filter(self, vmag_range):
+        """Removes stars which have attribute Binary_Cut == True"""
+        meets_lower_bound = self.Vmag > vmag_range[0]
+        meets_upper_bound = self.Vmag < vmag_range[1]
+        i = np.where(meets_lower_bound & meets_upper_bound)[0]
+        self.revise_lists(i)
 
-        # filter out systems which do not reach the completeness threshold
-        self.completeness_filter()
-        if self.explainFiltering:
-            print("%d targets remain after completeness filter." % self.nStars)
+    def ang_diam_filter(self):
+        """Remove stars which are larger than the IWA."""
+        # angular radius of each star
+        ang_rad = self.diameter / 2
+        IWA = self.OpticalSystem.IWA
+        # indices of stars with angular radius less than IWA
+        i = np.where(ang_rad < IWA)[0]
+        self.revise_lists(i)
 
     def nan_filter(self):
         """Filters out targets where required values are nan"""

--- a/EXOSIMS/StarCatalog/SIMBADCatalog.py
+++ b/EXOSIMS/StarCatalog/SIMBADCatalog.py
@@ -131,7 +131,7 @@ class SIMBADCatalog(StarCatalog):
                     bc = x.BINARY_CUT.tolist()
                     y["Binary_Cut"] = [False] * len(bc)
                     for i in range(len(bc)):
-                        if bc[i] == "cut":
+                        if type(bc[i]) is str and bc[i] == "cut":
                             y["Binary_Cut"][i] = True
                 else:
                     y[mat2pkl[field]] = getattr(x, field).tolist()

--- a/EXOSIMS/StarCatalog/SIMBADCatalog.py
+++ b/EXOSIMS/StarCatalog/SIMBADCatalog.py
@@ -131,7 +131,7 @@ class SIMBADCatalog(StarCatalog):
                     bc = x.BINARY_CUT.tolist()
                     y["Binary_Cut"] = [False] * len(bc)
                     for i in range(len(bc)):
-                        if type(bc[i]) is str and bc[i] == "cut":
+                        if isinstance(bc[i], str) and bc[i] == "cut":
                             y["Binary_Cut"][i] = True
                 else:
                     y[mat2pkl[field]] = getattr(x, field).tolist()

--- a/EXOSIMS/TargetList/KnownRVPlanetsTargetList.py
+++ b/EXOSIMS/TargetList/KnownRVPlanetsTargetList.py
@@ -21,7 +21,6 @@ class KnownRVPlanetsTargetList(TargetList):
     """
 
     def __init__(self, **specs):
-
         # define mapping between attributes we need and the IPAC data
         # table loaded in the Planet Population module
         self.atts_mapping = {
@@ -171,7 +170,7 @@ class KnownRVPlanetsTargetList(TargetList):
         self.Binary_Cut = np.zeros(self.nStars, dtype=bool)
         self.hasKnownPlanet = np.ones(self.nStars, dtype=bool)
 
-    def filter_target_list(self, **specs):
+    def filter_target_list(self, filters):
         """Filtering is done as part of populating the table, so this
         method is overloaded to do nothing.
         """

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ astropy>=5.0.0
 jplephem>=2.20.0
 ortools>=9.0
 h5py>=3.7.0
-astroquery>=0.4.6,<0.4.9
+astroquery==0.4.6
 exo-det-box
 tqdm>=4.59
 pandas>=1.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ astropy>=5.0.0
 jplephem>=2.20.0
 ortools>=9.0
 h5py>=3.7.0
-astroquery>=0.4.6
+astroquery>=0.4.6,<0.4.9
 exo-det-box
 tqdm>=4.59
 pandas>=1.3

--- a/tests/TargetList/test_KnownRVPlanetsTargetList.py
+++ b/tests/TargetList/test_KnownRVPlanetsTargetList.py
@@ -303,7 +303,7 @@ class TestKnownRVPlanetsTargetListMethods(unittest.TestCase):
         """
         tlist = self.fixture
         keys = sorted(list(tlist.__dict__))  # makes a copy
-        tlist.filter_target_list()
+        tlist.filter_target_list({})
         self.assertEqual(tlist._modtype, "TargetList")
         # just ensure the same keys are still present
         self.assertListEqual(keys, sorted(list(tlist.__dict__)))


### PR DESCRIPTION
## Describe your changes
Added a new system to handle optional target list filters that maintains backwards compatibility. 
### TargetList optional filter system
There's a new "optional_filters" keyword that can be provided that dictates which filters to apply. It is intended to be used with these filter methods:
- `binary_filter`
- `outside_IWA_filter`
- `life_expectancy_filter`
- `main_sequence_filter`
- `fgk_filter`
- `vis_mag_filter` (takes Vmagcrit as input)
- `max_dmag_filter`
- `completeness_filter` (gets run after the completeness values are calculated)
- `vmag_filter` (takes vmag_range as input)
- `ang_diam_filter`
where the filters can be provided in the input JSON with the format
```
"optional_filters": {
    "binary_filter": {"enabled": true},
    "outside_IWA_filter": {"enabled": false},
    "ang_diam_filter": {"enabled": true},
    "vmag_filter": { "enabled": true, "params": {"vmag_range": [4,12]} }
  }
```
where the "params" key holds any arguments that are passed to the filter function (there are no defaults currently set for those parameters but could be done with keyword arguments). Everything except `completeness_filter` is run prior to calculating intCutoff_and_saturation_dMag values which can reduce the computation time there.

#### Backwards compatibility
The logic around existing filters that run in the TL init like `nan_filter`, `zero_lum_filter`, `cherry_pick_stars`, etc. are all unchanged. The keyword `filterBinaries` still works, but raises a warning (not error) and gets overridden in the case that the user provides a conflicting value in the `optional_filters` dictionary. 

#### Defaults
The filters that are on by default are the same as before the pull: `binary_filter`, `outside_IWA_filter`, and `completeness_filter`. If we want to enable any others by default it's an easy change.

### New filters
- `vmag_filter`: Filters out any stars that have Vmag values outside the provided range
- `ang_diam_filter`: Filters out any stars that have angular radius larger than minimum IWA.

### SIMBADCatalog bugfix
I am getting an error in SIMBAD catalog where all empty values from scipy's `loadmat` function are empty arrays and therefore can't be compared with `bc[i]=='cut'` since array comparisons have ambiguous truthiness. The change itself is just making the comparison `type(bc[i])==str and bc[i]=='cut'` which shouldn't affect any functionality. It's not clear to me why this behavior is different now, but I tested python 3.10, 3.11, and 3.12 with various scipy versions and all had the same error (which makes me think I have been using the same SIMBAD300.pkl file for a long time and clearing my .EXOSIMS cache revealed a functionality change from a while ago).

## Type of change

- New feature (non-breaking change which adds functionality)
- Bug fix

## Reference any relevant issues (don't forget the #)
#404 

## Checklist before requesting a review
- [x] I have verified that all unit tests pass in a clean virtual environment and added new unit tests, as needed
- [x] I have run ``e2eTests`` and added new test scripts, as needed
- [x] I have verified that all docstrings are properly formatted and added new documentation, as needed