### PR TITLE
Eccanom zero-size return and gen_update avoid exiting loop accidentally

### DIFF
--- a/EXOSIMS/Completeness/BrownCompleteness.py
+++ b/EXOSIMS/Completeness/BrownCompleteness.py
@@ -347,7 +347,7 @@ class BrownCompleteness(Completeness):
                 for num in range(5):
                     if num == 0:
                         self.updates[sInd, num] = TL.int_comp[sInd]
-                    if not pInds.any():
+                    if pInds.size == 0:
                         break
                     # find Eccentric anomaly
                     if num == 0:

--- a/EXOSIMS/util/eccanom.py
+++ b/EXOSIMS/util/eccanom.py
@@ -17,15 +17,16 @@ def eccanom(M, e):
     Returns:
         E (float or ndarray):
             eccentric anomaly
-
     """
 
     # make sure M and e are of the correct format.
     # if 1 value provided for e, array must match size of M
     M = np.array(M).astype(float)
+    e = np.array(e).astype(float)
+    if M.size == 0 or e.size == 0:
+        return np.array([])
     if not M.shape:
         M = np.array([M])
-    e = np.array(e).astype(float)
     if not e.shape:
         e = np.array([e] * len(M))
 

--- a/tests/util/test_eccanom.py
+++ b/tests/util/test_eccanom.py
@@ -30,6 +30,12 @@ class TestUtilityMethods(unittest.TestCase):
 
         print("eccanom()")
 
+        # empty input should return empty output
+        empty_input = np.array([])
+        empty_output = eccanom(empty_input, 0.1)
+        self.assertEqual(empty_output.shape, (0,))
+        self.assertTrue(isinstance(empty_output, np.ndarray))
+
         # precomputed from newtonm.m in Vallado's Matlab source code
         tabulation = {
             # a few systematically-chosen values, a few random ones


### PR DESCRIPTION
## Describe your changes
Fixed two bugs in utility functions:
- Modified eccanom to correctly handle empty inputs by returning an empty array early, preventing a ValueError from np.max on zero-size arrays.
- Updated gen_update method in BrownCompleteness.py to properly detect empty pInds arrays by replacing the faulty if not pInds.any() condition with if pInds.size == 0, ensuring correct loop behavior.

## Type of change
Bug fix (non-breaking change which fixes an issue)

## Reference any relevant issues (don't forget the #)
Fixes #372
Fixes #380

## Checklist before requesting a review
- [x] I have verified that all unit tests pass in a clean virtual environment and added new unit tests, as needed
- [x] I have run ``e2eTests`` and added new test scripts, as needed
- [x] I have verified that all docstrings are properly formatted and added new documentation, as needed
