### PR TITLE
Filter system_fbeta to avoid incorrect indexing

### DIFF
--- a/EXOSIMS/Prototypes/TargetList.py
+++ b/EXOSIMS/Prototypes/TargetList.py
@@ -510,6 +510,10 @@ class TargetList(object):
         if self.explainFiltering:
             print("%d targets imported from star catalog." % self.nStars)
 
+        # Initialize system_fbeta, will be overwritten by calc_all_JEZ0
+        # but is needed for revise_lists()
+        self.system_fbeta = np.ones(self.nStars)
+
         # remove any requested stars from TargetList
         if self.popStars is not None:
             keep = np.ones(self.nStars, dtype=bool)
@@ -645,9 +649,11 @@ class TargetList(object):
             allInds = np.arange(self.nStars, dtype=int)
             missionStart = Time(float(missionStart), format="mjd", scale="tai")
             self.starprop_static = (
-                lambda sInds, currentTime, eclip=False, c1=self.starprop(
-                    allInds, missionStart, eclip=False
-                ), c2=self.starprop(allInds, missionStart, eclip=True): (
+                lambda sInds,
+                currentTime,
+                eclip=False,
+                c1=self.starprop(allInds, missionStart, eclip=False),
+                c2=self.starprop(allInds, missionStart, eclip=True): (
                     c1[sInds] if not (eclip) else c2[sInds]  # noqa: E275
                 )
             )
@@ -1656,6 +1662,7 @@ class TargetList(object):
             self.star_fluxes[key] = self.star_fluxes[key][sInds]
         for key in self.JEZ0:
             self.JEZ0[key] = self.JEZ0[key][sInds]
+        self.system_fbeta = self.system_fbeta[sInds]
         try:
             self.Completeness.revise_updates(sInds)
         except AttributeError:

--- a/EXOSIMS/Prototypes/TargetList.py
+++ b/EXOSIMS/Prototypes/TargetList.py
@@ -649,11 +649,9 @@ class TargetList(object):
             allInds = np.arange(self.nStars, dtype=int)
             missionStart = Time(float(missionStart), format="mjd", scale="tai")
             self.starprop_static = (
-                lambda sInds,
-                currentTime,
-                eclip=False,
-                c1=self.starprop(allInds, missionStart, eclip=False),
-                c2=self.starprop(allInds, missionStart, eclip=True): (
+                lambda sInds, currentTime, eclip=False, c1=self.starprop(
+                    allInds, missionStart, eclip=False
+                ), c2=self.starprop(allInds, missionStart, eclip=True): (
                     c1[sInds] if not (eclip) else c2[sInds]  # noqa: E275
                 )
             )


### PR DESCRIPTION
## Describe your changes
I realized that we also need to revise the fbeta values when filtering the target list. Otherwise we'll be using the wrong star inclination factor since we moved the multiplication of the system fbeta values to SimulatedUniverse.

* Added initialization of `self.system_fbeta` as an array of ones in the `__init__` method to ensure it exists before all `revise_lists()` calls. It then gets overwritten with the correct values.
* Updated the `revise_lists` method to slice `self.system_fbeta` according to the filtered star indices.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist before requesting a review
- [x] I have verified that all unit tests pass in a clean virtual environment and added new unit tests, as needed
- [x] I have run ``e2eTests`` and added new test scripts, as needed
- [x] I have verified that all docstrings are properly formatted and added new documentation, as needed
