### PR TITLE
Add optional fixed_nEZ_val 

### DIFF
--- a/EXOSIMS/Prototypes/SimulatedUniverse.py
+++ b/EXOSIMS/Prototypes/SimulatedUniverse.py
@@ -39,6 +39,8 @@ class SimulatedUniverse(object):
             inclinations.
         commonSystemnEZ (bool):
             Assume same zodi for planets in the same system. Defaults to True.
+        fixed_nEZ_val (float):
+            A value representing the number of exozodi applied to *every* star. Defaults to None.
         **specs:
             :ref:`sec:inputspec`
 
@@ -159,6 +161,7 @@ class SimulatedUniverse(object):
         commonSystemPlane=False,
         commonSystemPlaneParams=[0, 2.25, 0, 2.25],
         commonSystemnEZ=True,
+        fixed_nEZ_val=None,
         **specs,
     ):
         self.AU_div_day = u.AU / u.day
@@ -183,6 +186,10 @@ class SimulatedUniverse(object):
         # Set the number of exozodi
         self.commonSystemnEZ = commonSystemnEZ
         self._outspec["commonSystemnEZ"] = commonSystemnEZ
+
+        # A fixed number of exozodi for every system
+        self.fixed_nEZ_val = fixed_nEZ_val
+        self._outspec["fixed_nEZ_val"] = fixed_nEZ_val
 
         # save fixed number of planets to generate
         self.fixedPlanPerStar = fixedPlanPerStar
@@ -362,7 +369,9 @@ class SimulatedUniverse(object):
             self.gen_M0()  # initial mean anomaly
             self.Mp = PPop.gen_mass(self.nPlans)  # mass
 
-        if self.commonSystemnEZ:
+        if self.fixed_nEZ_val is not None:
+            self.nEZ = np.ones((self.nPlans,)) * self.fixed_nEZ_val
+        elif self.commonSystemnEZ:
             # Assign the same nEZ to all planets in the system
             self.nEZ = ZL.gen_systemnEZ(TL.nStars)[self.plan2star]
         else:

--- a/EXOSIMS/SimulatedUniverse/DulzPlavchanUniverse.py
+++ b/EXOSIMS/SimulatedUniverse/DulzPlavchanUniverse.py
@@ -41,7 +41,9 @@ class DulzPlavchanUniverse(SimulatedUniverse):
             []
         )  # Used to switch select specific phase function for each planet
         ZL = self.ZodiacalLight
-        if self.commonSystemnEZ:
+        if self.fixed_nEZ_val is not None:
+            self.nEZ = np.ones((self.nPlans,)) * self.fixed_nEZ_val
+        elif self.commonSystemnEZ:
             # Assign the same nEZ to all planets in the system
             self.nEZ = ZL.gen_systemnEZ(TL.nStars)[self.plan2star]
         else:

--- a/EXOSIMS/SimulatedUniverse/DulzPlavchanUniverseEarthsOnly.py
+++ b/EXOSIMS/SimulatedUniverse/DulzPlavchanUniverseEarthsOnly.py
@@ -71,7 +71,9 @@ class DulzPlavchanUniverseEarthsOnly(SimulatedUniverse):
         else:
             self.phiIndex = np.asarray([])
         ZL = self.ZodiacalLight
-        if self.commonSystemnEZ:
+        if self.fixed_nEZ_val is not None:
+            self.nEZ = np.ones((self.nPlans,)) * self.fixed_nEZ_val
+        elif self.commonSystemnEZ:
             # Assign the same nEZ to all planets in the system
             self.nEZ = ZL.gen_systemnEZ(TL.nStars)[self.plan2star]
         else:

--- a/EXOSIMS/SimulatedUniverse/KeplerLikeUniverse.py
+++ b/EXOSIMS/SimulatedUniverse/KeplerLikeUniverse.py
@@ -61,7 +61,9 @@ class KeplerLikeUniverse(SimulatedUniverse):
             []
         )  # Used to switch select specific phase function for each planet
         ZL = self.ZodiacalLight
-        if self.commonSystemnEZ:
+        if self.fixed_nEZ_val is not None:
+            self.nEZ = np.ones((self.nPlans,)) * self.fixed_nEZ_val
+        elif self.commonSystemnEZ:
             # Assign the same nEZ to all planets in the system
             self.nEZ = ZL.gen_systemnEZ(TL.nStars)[self.plan2star]
         else:

--- a/EXOSIMS/SimulatedUniverse/KnownRVPlanetsUniverse.py
+++ b/EXOSIMS/SimulatedUniverse/KnownRVPlanetsUniverse.py
@@ -106,7 +106,9 @@ class KnownRVPlanetsUniverse(SimulatedUniverse):
             []
         )  # Used to switch select specific phase function for each planet
         ZL = self.ZodiacalLight
-        if self.commonSystemnEZ:
+        if self.fixed_nEZ_val is not None:
+            self.nEZ = np.ones((self.nPlans,)) * self.fixed_nEZ_val
+        elif self.commonSystemnEZ:
             # Assign the same nEZ to all planets in the system
             self.nEZ = ZL.gen_systemnEZ(TL.nStars)[self.plan2star]
         else:

--- a/EXOSIMS/SimulatedUniverse/SAG13Universe.py
+++ b/EXOSIMS/SimulatedUniverse/SAG13Universe.py
@@ -61,7 +61,9 @@ class SAG13Universe(SimulatedUniverse):
                 []
             )  # Used to switch select specific phase function for each planet
         ZL = self.ZodiacalLight
-        if self.commonSystemnEZ:
+        if self.fixed_nEZ_val is not None:
+            self.nEZ = np.ones((self.nPlans,)) * self.fixed_nEZ_val
+        elif self.commonSystemnEZ:
             # Assign the same nEZ to all planets in the system
             self.nEZ = ZL.gen_systemnEZ(TL.nStars)[self.plan2star]
         else:


### PR DESCRIPTION
## Describe your changes
Adding a optional input that holds the exozodi for all stars and planets constant to some input value. This is useful for debugging and comparison purposes, as AYO and some ETCs use a constant nEZ value. It's just a new flag to SimulatedUniverse that affects the gen_physical_properties call. I updated all SimulatedUniverse modules that overwrite gen_physical_properties to use same logic when generating nEZ values. It defaults to None if not set.

## Type of change

- New feature (non-breaking change which adds functionality)

## Reference any relevant issues (don't forget the #)


## Checklist before requesting a review
- [x] I have verified that all unit tests pass in a clean virtual environment and added new unit tests, as needed
- [x] I have run ``e2eTests`` and added new test scripts, as needed
- [x] I have verified that all docstrings are properly formatted and added new documentation, as needed
