### PR TITLE
Fix StringArray nan handling in HPIC

### DIFF
--- a/EXOSIMS/StarCatalog/HPIC.py
+++ b/EXOSIMS/StarCatalog/HPIC.py
@@ -19,7 +19,6 @@ class HPIC(StarCatalog):
     """
 
     def __init__(self, **specs):
-
         downloadsdir = get_downloads_dir()
         localfile = os.path.join(downloadsdir, "HPIC", "full_HPIC.txt")
         if not os.path.exists(localfile):
@@ -67,7 +66,12 @@ class HPIC(StarCatalog):
         for att in atts_mapping:
             if atts_mapping[att][1] is None:
                 tmp = data[atts_mapping[att][0]].values
-                if tmp.dtype.name == "object":
+                if tmp.dtype.name in ("object", "str"):
+                    # A pandas StringArray, like Spec, has dtype "str" but can
+                    # contain float nan for missing values which mess up things
+                    # downstream.
+                    # Convert to numpy array first, then force type to string
+                    tmp = np.array(tmp, dtype=object)
                     tmp[pandas.isna(tmp)] = ""
                     tmp = tmp.astype(str)
                 setattr(self, att, tmp)


### PR DESCRIPTION
## Describe your changes
Updating the HPIC filtering to properly force missing values in string fields to be assigned empty strings instead of floating point nan values.

The TargetList/StarCatalog expects attributes like `Spec` to have dtype=str. However, HPIC is loaded via pandas which (for some reason) treats missing data as a floating point nan value even for a pandas `StringArray` which gets labeled as dtype=str, and therefore wasn't caught by the original HPIC filter that checked for the `object` dtype. So I updated the filtering in HPIC to force string arrays into numpy and then convert nan values to empty strings.

This fixes a bug I ran into where TargetList would send MeanStars a floating point nan as a spectral type and MeanStars would error out.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Reference any relevant issues (don't forget the #)


## Checklist before requesting a review
- [x] I have verified that all unit tests pass in a clean virtual environment and added new unit tests, as needed
- [x] I have run ``e2eTests`` and added new test scripts, as needed
- [x] I have verified that all docstrings are properly formatted and added new documentation, as needed
